### PR TITLE
INTERLOK-3027 Enable UML javadocs for lombok

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ ext {
   organizationName = "Adaptris Ltd"
 
   slf4jVersion = '1.7.28'
-  awsSDKVersion = '1.11.646'
   log4j2Version = '2.12.1'
   mockitoVersion = '3.1.0'
 }
@@ -40,6 +39,16 @@ ext.hostname = { ->
     return System.getenv("COMPUTERNAME")
   }
   return System.getenv("HOSTNAME")
+}
+
+ext.hasGraphViz = { ->
+  def app = "dot"
+  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    app = app + ".exe"
+  }
+  return System.getenv("PATH").split(File.pathSeparator).any{
+    java.nio.file.Paths.get("${it}").resolve(app).toFile().exists()
+  }
 }
 
 ext.gitBranchNameOrTimestamp = { branchName ->
@@ -100,6 +109,7 @@ subprojects {
 
   configurations {
     javadoc {}
+    umlDoclet {}
     offlineJavadocPackages {}
     all*.exclude group: 'c3p0'
     all*.exclude group: 'commons-logging'
@@ -134,6 +144,7 @@ subprojects {
     testCompile ("org.mockito:mockito-inline:$mockitoVersion")
 
     javadoc("com.adaptris:interlok-core-apt:$interlokCoreVersion") { changing= true}
+    umlDoclet("nl.talsmasoftware:umldoclet:1.1.4")
 
     offlineJavadocPackages ("com.adaptris:interlok-core:$interlokCoreVersion:javadoc@jar") { changing= true}
     offlineJavadocPackages ("com.adaptris:interlok-common:$interlokCoreVersion:javadoc@jar") { changing= true}
@@ -141,6 +152,9 @@ subprojects {
   }
 
   javadoc {
+    onlyIf {
+      !hasGraphViz()
+    }
     configure(options) {
       options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
       options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
@@ -148,6 +162,44 @@ subprojects {
       options.addStringOption "tagletpath", configurations.javadoc.asPath
     }
   }
+
+  task umlJavadoc(type: Javadoc) {
+    group 'Documentation'
+    description 'Build javadocs using plantuml + graphviz + umldoclet, if dot is available'
+
+    onlyIf {
+      hasGraphViz()
+    }
+    // Since we are using lombok, we have to switch the source.
+    // c.f. https://github.com/freefair/gradle-plugins/issues/132
+    // source = sourceSets.main.allJava
+    source = sourceSets.main.extensions.delombokTask
+    classpath = project.sourceSets.main.compileClasspath
+    configure(options) {
+      options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
+      options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
+      taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet"]
+      options.addStringOption "tagletpath", configurations.javadoc.asPath
+      options.docletpath = configurations.umlDoclet.files.asType(List)
+      options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
+      options.addStringOption "umlBasePath", destinationDir.getCanonicalPath()
+      options.addStringOption "umlImageFormat", "SVG"
+      options.addStringOption "umlExcludedReferences", "java.lang.Exception,java.lang.Object,java.lang.Enum"
+      options.addStringOption "umlIncludePrivateClasses","false"
+      options.addStringOption "umlIncludePackagePrivateClasses","false"
+      options.addStringOption "umlIncludeProtectedClasses","false"
+      options.addStringOption "umlIncludeAbstractSuperclassMethods","false"
+      options.addStringOption "umlIncludeConstructors","false"
+      options.addStringOption "umlIncludePublicFields","false"
+      options.addStringOption "umlIncludePackagePrivateFields","false"
+      options.addStringOption "umlIncludeProtectedFields", "false"
+      options.addStringOption "umlIncludeDeprecatedClasses", "false"
+      options.addStringOption "umlIncludePrivateInnerClasses", "false"
+      options.addStringOption "umlIncludePackagePrivateInnerClasses", "false"
+      options.addStringOption "umlIncludeProtectedInnerClasses","false"
+    }
+  }
+
 
   jacoco {
     toolVersion="0.8.3"
@@ -245,5 +297,5 @@ subprojects {
   }
 
   check.dependsOn jacocoTestReport
-
+  javadoc.dependsOn offlinePackageList, umlJavadoc
 }

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderFromUrl.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderFromUrl.java
@@ -38,7 +38,7 @@ import lombok.Setter;
  * <th>ResourceID</th>
  * <tr>
  * <td>https://azuredb.microsoft.com/</td>
- * <td>{@code ""} - the service will fail; since ResourceType must be set</td>
+ * <td>{@code ""} (the service will fail; since ResourceType must be set)</td>
  * <td>{@code ""}</td>
  * </tr>
  * <tr>

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderImpl.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderImpl.java
@@ -19,7 +19,15 @@ import lombok.Setter;
  */
 @NoArgsConstructor
 public abstract class CosmosAuthorizationHeaderImpl extends ServiceImp {
+  /**
+   * The default metadata key for the {@link #setTargetKey(String)}; set to be {@value #DEFAULT_METADATA_KEY}.
+   * 
+   */
   public static final String DEFAULT_METADATA_KEY = "Authorization";
+  /**
+   * The {@value #X_MS_DATE} header, added as metadata by the services.
+   * 
+   */
   public static final String X_MS_DATE = "x-ms-date";
 
   /**

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/ResourceTypeHelper.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/ResourceTypeHelper.java
@@ -33,6 +33,10 @@ public class ResourceTypeHelper {
         .toArray(String[]::new);
   }
 
+  /**
+   * Used by the InputFieldHint annotation for type-ahead.
+   * 
+   */
   public static String[] getResourceTypes() {
     return Arrays.copyOf(declaredConstants, declaredConstants.length);
   }
@@ -44,10 +48,21 @@ public class ResourceTypeHelper {
   }
 
 
-  // https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/ -> docs
-  // https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -> docs.
-  // so odd number of uri fragments, it's the last one,
-  // even number of uri fragments it's the penultimate one.
+  /**
+   * Parsing the ResourceType out of the URL.
+   * <p>
+   * Odd number of uri fragments, it's the last one, even number of uri fragments it's the penultimate one.
+   * <ul>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/ -> docs</li>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -> docs</li>
+   * <li>
+   * </ul>
+   * </p>
+   * 
+   * @param url the URL endpoint
+   * @return the ResourceType
+   * @see CosmosAuthorizationHeaderFromUrl
+   */
   public static String getResourceType(URL url) {
     String path = stripEnd(stripStart(defaultIfEmpty(url.getPath(), ""), "/"), "/");
     if (isEmpty(path)) {
@@ -60,10 +75,21 @@ public class ResourceTypeHelper {
     return trimToEmpty(fragments[fragments.length - 1]);
   }
 
-  // https://azuredb.microsoft.com/dbs/tempdb/colls -> dbs/tempdb
-  // https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -> dbs/tempdb/colls/tempcoll/docs/MyName.
-  // so odd number of uri fragments, then it's everything but the last one.
-  // even number of uri fragments it's all of them.
+  /**
+   * Parsing the ResourceID out of the URL.
+   * <p>
+   * odd number of uri fragments, then it's everything but the last one; even number of uri fragments it's all of them.
+   * <ul>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls -> dbs/tempdb</li>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -> dbs/tempdb/colls/tempcoll/docs/MyName</li>
+   * <li>
+   * </ul>
+   * </p>
+   * 
+   * @param url the URL endpoint
+   * @return the ResourceID.
+   * @see CosmosAuthorizationHeaderFromUrl
+   */
   public static String getResourceID(URL url) {
     String path = stripEnd(stripStart(defaultIfEmpty(url.getPath(), ""), "/"), "/");
     if (isEmpty(path)) {

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/package-info.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Components for interacting with Azure CosmosDB.
+ * 
+ */
+package com.adaptris.interlok.azure.cosmosdb;


### PR DESCRIPTION
- needs `source = sourceSets.main.extensions.delombokTask` in the umlJavadoc task.

Have raised a issue on the plugin itself; not sure where that will go, but we have a work-around.

Will be merged post 3.9.2 release