### PR TITLE
Fix failing build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.apache.tools.ant.filters.*
 plugins {
   id 'com.github.spotbugs' version '4.5.1' apply false
   id "io.freefair.lombok" version "5.3.0" apply false
-  id 'org.owasp.dependencycheck' version '6.0.2' apply false
+  id 'org.owasp.dependencycheck' version '6.0.3' apply false
 }
 
 ext {

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -4,7 +4,7 @@ ext {
 }
 
 dependencies {
-  compile group: "com.microsoft.azure", name: "msal4j", version: "1.6.2"
+  compile group: "com.microsoft.azure", name: "msal4j", version: "1.8.0"
   compile ("commons-codec:commons-codec:1.15")
   compile ("com.fasterxml.jackson.core:jackson-databind:2.11.3")
   compile ("com.fasterxml.jackson.core:jackson-core:2.11.3")
@@ -55,7 +55,7 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Components that interact Outlook/Exchange in Office365 ")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("target", "3.9.2+")
+        properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,office365,outlook,exchange")
         properties.appendNode("license", "false")
       }

--- a/interlok-azure-mail/build.gradle
+++ b/interlok-azure-mail/build.gradle
@@ -5,8 +5,9 @@ ext {
 
 dependencies {
   compile project(':interlok-azure-core')
-  compile group: "com.microsoft.azure", name: "msal4j", version: "1.6.2"
-  compile group: "com.microsoft.graph", name: "microsoft-graph", version: "2.3.1"
+  compile group: "com.microsoft.azure", name: "msal4j", version: "1.8.0"
+  compile group: "com.microsoft.graph", name: "microsoft-graph", version: "2.3.2"
+  compile ("com.google.guava:guava:29.0-jre")
   compile ("commons-codec:commons-codec:1.15")
   compile ("com.fasterxml.jackson.core:jackson-databind:2.11.3")
   compile ("com.fasterxml.jackson.core:jackson-core:2.11.3")
@@ -57,7 +58,7 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Components that interact Outlook/Exchange in Office365 ")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("target", "3.9.2+")
+        properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,office365,outlook,exchange")
         properties.appendNode("license", "false")
       }

--- a/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailConsumerTest.java
+++ b/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailConsumerTest.java
@@ -104,7 +104,7 @@ public class O365MailConsumerTest extends ExampleConsumerCase
   @Override
   protected List<StandaloneConsumer> retrieveObjectsForSampleConfig()
   {
-    List<StandaloneConsumer> result = new ArrayList();
+    List<StandaloneConsumer> result = new ArrayList<>();
     for (Poller poller : POLLERS)
     {
       StandaloneConsumer standaloneConsumer = (StandaloneConsumer)retrieveObjectForSampleConfig();


### PR DESCRIPTION
## Motivation

Failing build on Jenkins due to some vulnerabilities on some older versions of msal4j, microsoft-graph and guava

## Modification

- Upgrade msal4j to 1.8.0
- Upgrade microsoft-graph to 1.8.0
- Upgrade owasp deps check to 6.0.3
- Add direct dependency on guava to override it to 29.0-jre

## Result

The build is successful and the vulnerabilities are fixed.

## Testing

_gradlew check_ and _gradlew dependencyCheckAnalyze_ should be successful.
