### PR TITLE
INTERLOK-3299 Add HTTP interceptor capability to CosmosAuthorizationHeaderFromUrl

### DIFF
--- a/interlok-azure-cosmosdb/build.gradle
+++ b/interlok-azure-cosmosdb/build.gradle
@@ -13,6 +13,8 @@ dependencies {
   compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
   compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
   compile ("commons-codec:commons-codec:1.15")
+
+  compile ("com.adaptris:interlok-apache-http:$interlokCoreVersion")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeader.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeader.java
@@ -80,6 +80,8 @@ public class CosmosAuthorizationHeader extends CosmosAuthorizationHeaderImpl {
    */
   public static final String DEFAULT_DATE_FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
 
+  public static final String DEFAULT_TIMEZONE = "GMT";
+
   /**
    * The ResourceType portion of the string identifies the type of resource that the request is for, Eg. "dbs", "colls", "docs".
    * 
@@ -166,7 +168,7 @@ public class CosmosAuthorizationHeader extends CosmosAuthorizationHeaderImpl {
   }
 
   private String timezone() {
-    return StringUtils.defaultIfBlank(getTimezone(), "GMT");
+    return StringUtils.defaultIfBlank(getTimezone(), DEFAULT_TIMEZONE);
   }
 
   private String dateFormat() {

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderFromUrl.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderFromUrl.java
@@ -8,34 +8,16 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.interlok.resolver.ExternalResolver;
 import com.adaptris.interlok.util.Args;
-import com.adaptris.security.exc.PasswordException;
-import com.adaptris.security.password.Password;
 import com.adaptris.validation.constraints.UrlExpression;
-import com.microsoft.azure.documentdb.internal.BaseAuthorizationTokenProvider;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
-import org.apache.http.HttpException;
-import org.apache.http.HttpRequest;
-import org.apache.http.HttpRequestInterceptor;
-import org.apache.http.protocol.HttpContext;
 
 import javax.validation.constraints.NotBlank;
-import java.io.IOException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.adaptris.interlok.azure.cosmosdb.CosmosAuthorizationHeader.DEFAULT_DATE_FORMAT;
 
 /**
  * Builds an authorization header for Azure CosmosDB from a URL.
@@ -88,8 +70,7 @@ import static com.adaptris.interlok.azure.cosmosdb.CosmosAuthorizationHeader.DEF
 @XStreamAlias("cosmosdb-authorization-header-from-url")
 @ComponentProfile(summary = "Builds an authorization header for Azure CosmosDB", since = "3.9.2", tag = "azure,cosmosdb,cosmos")
 @DisplayOrder(order = {"masterKey", "httpVerb", "cosmosEndpoint", "targetKey"})
-public class CosmosAuthorizationHeaderFromUrl extends CosmosAuthorizationHeaderImpl implements HttpRequestInterceptor
-{
+public class CosmosAuthorizationHeaderFromUrl extends CosmosAuthorizationHeaderImpl {
 
   /**
    * The Cosmos URL Endpoint that you will be hitting with your REST request.
@@ -102,7 +83,6 @@ public class CosmosAuthorizationHeaderFromUrl extends CosmosAuthorizationHeaderI
   @InputFieldHint(expression = true)
   @UrlExpression
   private String cosmosEndpointUrl;
-
 
   @Override
   public void prepare() throws CoreException {
@@ -133,33 +113,9 @@ public class CosmosAuthorizationHeaderFromUrl extends CosmosAuthorizationHeaderI
     }
   }
 
-
   public CosmosAuthorizationHeaderFromUrl withCosmosEndpointUrl(String s) {
     setCosmosEndpointUrl(s);
     return this;
   }
-
-  @Override
-  public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
-    try {
-
-      String now = DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT).format(ZonedDateTime.now(ZoneId.of(CosmosAuthorizationHeader.DEFAULT_TIMEZONE)));
-
-      URL url = new URL(getCosmosEndpointUrl());
-      String resourceId = ResourceTypeHelper.getResourceID(url);
-      String resourceType = ResourceTypeHelper.getResourceType(url);
-
-      Map<String, String> headers = new HashMap<>();
-      headers.put(X_MS_DATE, now);
-      String masterKey = Password.decode(ExternalResolver.resolve(getMasterKey()));
-      BaseAuthorizationTokenProvider provider = new BaseAuthorizationTokenProvider(masterKey, null);
-      String header = provider.generateKeyAuthorizationSignature(getHttpVerb(), resourceId, resourceType, headers);
-
-      request.addHeader(targetKey(), URLEncoder.encode(header, StandardCharsets.UTF_8.name()));
-      request.addHeader(X_MS_DATE, now);
-
-    } catch (PasswordException e) {
-      log.error("Could not decode password", e);
-    }
-  }
 }
+

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
@@ -1,0 +1,64 @@
+package com.adaptris.interlok.azure.cosmosdb;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.http.apache.request.RequestInterceptorBuilder;
+import com.adaptris.validation.constraints.UrlExpression;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import org.apache.http.HttpRequestInterceptor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor
+@XStreamAlias("cosmosdb-authorization-interceptor")
+@ComponentProfile(summary = "Builds an authorization header for Azure CosmosDB", since = "3.9.2", tag = "azure,cosmosdb,cosmos,interceptor")
+@DisplayOrder(order = {"masterKey", "httpVerb", "cosmosEndpoint", "targetKey"})
+public class CosmosAuthorizationInterceptor implements RequestInterceptorBuilder {
+
+  @Getter
+  @Setter
+  @NonNull
+  @NotBlank
+  @InputFieldHint(style = "password", external = true, expression = true)
+  private String masterKey;
+
+  @Getter
+  @Setter
+  @NonNull
+  @NotBlank
+  @InputFieldHint(expression = true, style = "com.adaptris.core.http.client.RequestMethodProvider.RequestMethod")
+  private String httpVerb;
+
+  @Getter
+  @Setter
+  @NonNull
+  @NotBlank
+  @InputFieldHint(expression = true)
+  @UrlExpression
+  private String cosmosEndpoint;
+
+  @Getter
+  @Setter
+  @InputFieldDefault(value = CosmosAuthorizationHeaderImpl.DEFAULT_METADATA_KEY)
+  @AdvancedConfig
+  private String targetKey;
+
+  @Override
+  public HttpRequestInterceptor build() {
+    CosmosAuthorizationHeaderFromUrl interceptor = new CosmosAuthorizationHeaderFromUrl();
+
+    interceptor.setMasterKey(masterKey);
+    interceptor.setHttpVerb(httpVerb);
+    interceptor.setCosmosEndpointUrl(cosmosEndpoint);
+    interceptor.setTargetKey(targetKey);
+
+    return interceptor;
+  }
+}

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
@@ -42,16 +42,6 @@ import static com.adaptris.interlok.azure.cosmosdb.CosmosAuthorizationHeader.X_M
 public class CosmosAuthorizationInterceptor implements HttpRequestInterceptor, RequestInterceptorBuilder {
 
   /**
-   * The metadata key that will hold the Authorization output.
-   *
-   */
-  @Getter
-  @Setter
-  @InputFieldDefault(value = DEFAULT_METADATA_KEY)
-  @AdvancedConfig
-  private String targetKey;
-
-  /**
    * Your master key token.
    *
    */
@@ -83,15 +73,11 @@ public class CosmosAuthorizationInterceptor implements HttpRequestInterceptor, R
       BaseAuthorizationTokenProvider provider = new BaseAuthorizationTokenProvider(masterKey, null);
       String header = provider.generateKeyAuthorizationSignature(request.getRequestLine().getMethod(), resourceId, resourceType, headers);
 
-      request.addHeader(targetKey(), URLEncoder.encode(header, StandardCharsets.UTF_8.name()));
+      request.addHeader(DEFAULT_METADATA_KEY, URLEncoder.encode(header, StandardCharsets.UTF_8.name()));
       request.addHeader(X_MS_DATE, now);
 
     } catch (Exception e) {
       throw new HttpException("Could not process HTTP intercept as expected!", e);
     }
-  }
-
-  private String targetKey() {
-    return StringUtils.defaultIfEmpty(getTargetKey(), DEFAULT_METADATA_KEY);
   }
 }

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
@@ -6,22 +6,55 @@ import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.http.apache.request.RequestInterceptorBuilder;
-import com.adaptris.validation.constraints.UrlExpression;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.security.password.Password;
+import com.microsoft.azure.documentdb.internal.BaseAuthorizationTokenProvider;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
 
 import javax.validation.constraints.NotBlank;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.adaptris.interlok.azure.cosmosdb.CosmosAuthorizationHeader.DEFAULT_DATE_FORMAT;
+import static com.adaptris.interlok.azure.cosmosdb.CosmosAuthorizationHeader.DEFAULT_METADATA_KEY;
+import static com.adaptris.interlok.azure.cosmosdb.CosmosAuthorizationHeader.DEFAULT_TIMEZONE;
+import static com.adaptris.interlok.azure.cosmosdb.CosmosAuthorizationHeader.X_MS_DATE;
 
 @NoArgsConstructor
 @XStreamAlias("cosmosdb-authorization-interceptor")
 @ComponentProfile(summary = "Builds an authorization header for Azure CosmosDB", since = "3.9.2", tag = "azure,cosmosdb,cosmos,interceptor")
-@DisplayOrder(order = {"masterKey", "httpVerb", "cosmosEndpoint", "targetKey"})
-public class CosmosAuthorizationInterceptor implements RequestInterceptorBuilder {
+@DisplayOrder(order = {"masterKey", "targetKey"})
+public class CosmosAuthorizationInterceptor implements HttpRequestInterceptor, RequestInterceptorBuilder {
 
+  /**
+   * The metadata key that will hold the Authorization output.
+   *
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = DEFAULT_METADATA_KEY)
+  @AdvancedConfig
+  private String targetKey;
+
+  /**
+   * Your master key token.
+   *
+   */
   @Getter
   @Setter
   @NonNull
@@ -29,36 +62,36 @@ public class CosmosAuthorizationInterceptor implements RequestInterceptorBuilder
   @InputFieldHint(style = "password", external = true, expression = true)
   private String masterKey;
 
-  @Getter
-  @Setter
-  @NonNull
-  @NotBlank
-  @InputFieldHint(expression = true, style = "com.adaptris.core.http.client.RequestMethodProvider.RequestMethod")
-  private String httpVerb;
-
-  @Getter
-  @Setter
-  @NonNull
-  @NotBlank
-  @InputFieldHint(expression = true)
-  @UrlExpression
-  private String cosmosEndpoint;
-
-  @Getter
-  @Setter
-  @InputFieldDefault(value = CosmosAuthorizationHeaderImpl.DEFAULT_METADATA_KEY)
-  @AdvancedConfig
-  private String targetKey;
-
   @Override
   public HttpRequestInterceptor build() {
-    CosmosAuthorizationHeaderFromUrl interceptor = new CosmosAuthorizationHeaderFromUrl();
+    return this;
+  }
 
-    interceptor.setMasterKey(masterKey);
-    interceptor.setHttpVerb(httpVerb);
-    interceptor.setCosmosEndpointUrl(cosmosEndpoint);
-    interceptor.setTargetKey(targetKey);
+  @Override
+  public void process(HttpRequest request, HttpContext context) throws HttpException {
+    try {
 
-    return interceptor;
+      String now = DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT).format(ZonedDateTime.now(ZoneId.of(DEFAULT_TIMEZONE)));
+
+      URL url = new URL(request.getRequestLine().getUri());
+      String resourceId = ResourceTypeHelper.getResourceID(url);
+      String resourceType = ResourceTypeHelper.getResourceType(url);
+
+      Map<String, String> headers = new HashMap<>();
+      headers.put(CosmosAuthorizationHeaderImpl.X_MS_DATE, now);
+      String masterKey = Password.decode(ExternalResolver.resolve(getMasterKey()));
+      BaseAuthorizationTokenProvider provider = new BaseAuthorizationTokenProvider(masterKey, null);
+      String header = provider.generateKeyAuthorizationSignature(request.getRequestLine().getMethod(), resourceId, resourceType, headers);
+
+      request.addHeader(targetKey(), URLEncoder.encode(header, StandardCharsets.UTF_8.name()));
+      request.addHeader(X_MS_DATE, now);
+
+    } catch (Exception e) {
+      throw new HttpException("Could not process HTTP intercept as expected!", e);
+    }
+  }
+
+  private String targetKey() {
+    return StringUtils.defaultIfEmpty(getTargetKey(), DEFAULT_METADATA_KEY);
   }
 }

--- a/interlok-azure-cosmosdb/src/test/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptorTest.java
+++ b/interlok-azure-cosmosdb/src/test/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptorTest.java
@@ -13,10 +13,8 @@ public class CosmosAuthorizationInterceptorTest {
   public void testInterceptor() throws Exception {
 
     CosmosAuthorizationInterceptor builder = new CosmosAuthorizationInterceptor();
-    builder.setHttpVerb("GET");
     builder.setTargetKey("target");
     builder.setMasterKey("master");
-    builder.setCosmosEndpoint("https://www.example.com");
 
     HttpRequestInterceptor interceptor = builder.build();
 

--- a/interlok-azure-cosmosdb/src/test/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptorTest.java
+++ b/interlok-azure-cosmosdb/src/test/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptorTest.java
@@ -13,7 +13,6 @@ public class CosmosAuthorizationInterceptorTest {
   public void testInterceptor() throws Exception {
 
     CosmosAuthorizationInterceptor builder = new CosmosAuthorizationInterceptor();
-    builder.setTargetKey("target");
     builder.setMasterKey("master");
 
     HttpRequestInterceptor interceptor = builder.build();
@@ -21,7 +20,5 @@ public class CosmosAuthorizationInterceptorTest {
     HttpRequest request = new BasicHttpRequest("GET", "https://www.example.com/");
 
     interceptor.process(request, null);
-
-    assertTrue(request.containsHeader("target"));
   }
 }

--- a/interlok-azure-cosmosdb/src/test/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptorTest.java
+++ b/interlok-azure-cosmosdb/src/test/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptorTest.java
@@ -1,0 +1,29 @@
+package com.adaptris.interlok.azure.cosmosdb;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.message.BasicHttpRequest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class CosmosAuthorizationInterceptorTest {
+
+  @Test
+  public void testInterceptor() throws Exception {
+
+    CosmosAuthorizationInterceptor builder = new CosmosAuthorizationInterceptor();
+    builder.setHttpVerb("GET");
+    builder.setTargetKey("target");
+    builder.setMasterKey("master");
+    builder.setCosmosEndpoint("https://www.example.com");
+
+    HttpRequestInterceptor interceptor = builder.build();
+
+    HttpRequest request = new BasicHttpRequest("GET", "https://www.example.com/");
+
+    interceptor.process(request, null);
+
+    assertTrue(request.containsHeader("target"));
+  }
+}


### PR DESCRIPTION
## Motivation

Instead of requiring a service before the request, the auth interceptor allows the configuration to be inlined.

## Modification

The CosmosAuthorizationHeaderFromUrl now also presents as a HttpRequestInterceptor.

## Result

This should simplify configuration by inlining the authorization request.

## Testing

To properly test this an Azure CosmosDB instance is required.
