### PR TITLE
feature/interlok-3187

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,19 @@
 
 The suggested name was `didactic-chainsaw`
 
-## Outlook / Office365
+## Azure Setup
 
 ### Requirements
 
 * Active Office365 subscription
-* An Azure Active Directory application with application the following
-  permissions, and with Admin Consent granted:
-  - Mail.Read
-  - Mail.ReadBasic
-  - Mail.ReadBasic.All
-  - Mail.ReadWrite
-  - Mail.Send
-  - User.Read
-  - User.Read.All
-* A user to send/receive email
+* An Azure Active Directory application with the necessary permissions
+  granted.
 
-The Office365 consumer and producer require the above because:
+It is worth remembering the following:
+
 * Daemon applications can work only in Azure AD tenants
 * As users cannot interact with daemon applications, incremental
   consent isn't possible
-* Users require an Exchange mailbox to send/receive email, and this
-  requires an Office365 subscription
 
 *[See here](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-daemon-overview) for an explanation.*
 
@@ -40,14 +31,7 @@ The Office365 consumer and producer require the above because:
 3. Add the necessary permissions
 ![Permissions](docs/o365-3.png)
 
-4. Ensure there is a user with an Exchange mailbox
-![Users Setup](docs/o365-4.png)
-
-### Azure Mail Setup
-
-The application ID, tenant ID, client secret and username are all
-required and should match those given in the Azure portal. When sending
-mail a list of recipients is obviously necessary too.
+### Dependencies
 
 List of library (JAR) dependencies:
 
@@ -62,3 +46,35 @@ List of library (JAR) dependencies:
 * SquareUp OKHTTP
 * SquareUp OKIO
 * Google GSON
+
+## Mail Setup
+
+Users require an Exchange mailbox to send/receive email, and this
+requires an Office365 subscription. The application ID, tenant ID,
+client secret and username are all required by Interlok and should match
+those given in the Azure portal. When sending mail a list of recipients
+is obviously necessary too.
+
+Necessary Azure application permissions:
+
+* Mail.Read
+* Mail.ReadBasic
+* Mail.ReadBasic.All
+* Mail.ReadWrite
+* Mail.Send
+* User.Read
+* User.Read.All
+
+1. Ensure there is a user with an Exchange mailbox
+![Users Setup](docs/o365-4.png)
+
+## OneDrive Setup
+
+* Files.Read.All
+* Files.ReadWrite.All
+* User.Read
+* User.Read.All
+
+Many of the prerequisites are the same as for EMail: the application ID,
+tenant ID, client secret and username are all required by Interlok and
+should match those given in the Azure portal.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ List of library (JAR) dependencies:
 * SquareUp OKIO
 * Google GSON
 
-## Mail Setup
+## Email
 
 Users require an Exchange mailbox to send/receive email, and this
 requires an Office365 subscription. The application ID, tenant ID,
@@ -68,13 +68,17 @@ Necessary Azure application permissions:
 1. Ensure there is a user with an Exchange mailbox
 ![Users Setup](docs/o365-4.png)
 
-## OneDrive Setup
+## OneDrive
 
 * Files.Read.All
 * Files.ReadWrite.All
 * User.Read
 * User.Read.All
 
-Many of the prerequisites are the same as for EMail: the application ID,
+Many of the prerequisites are the same as for Email: the application ID,
 tenant ID, client secret and username are all required by Interlok and
 should match those given in the Azure portal.
+
+In addition to a consumer and producer, there are also services for
+uploading/downloading documents, if it's necessary during the middle of
+a workflow.

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -90,6 +90,8 @@ publishing {
         properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,office365,outlook,exchange")
         properties.appendNode("license", "false")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-azure/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-azure")
       }
     }
   }

--- a/interlok-azure-cosmosdb/build.gradle
+++ b/interlok-azure-cosmosdb/build.gradle
@@ -65,6 +65,8 @@ publishing {
         properties.appendNode("target", "3.9.2+")
         properties.appendNode("tags", "azure,cosmosdb,cosmos")
         properties.appendNode("license", "false")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-azure/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-azure")
       }
     }
   }

--- a/interlok-azure-datalake/build.gradle
+++ b/interlok-azure-datalake/build.gradle
@@ -55,6 +55,8 @@ publishing {
         properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,data lake,data,lake")
         properties.appendNode("license", "false")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-azure/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-azure")
       }
     }
   }

--- a/interlok-azure-mail/build.gradle
+++ b/interlok-azure-mail/build.gradle
@@ -55,6 +55,8 @@ publishing {
         properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,office365,outlook,exchange")
         properties.appendNode("license", "false")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-azure/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-azure")
       }
     }
   }

--- a/interlok-azure-onedrive/build.gradle
+++ b/interlok-azure-onedrive/build.gradle
@@ -50,10 +50,10 @@ publishing {
       artifact sourcesJar { classifier "sources" }
       pom.withXml {
         asNode().appendNode("name", componentName)
-        asNode().appendNode("description", "Components that interact Outlook/Exchange in Office365 ")
+        asNode().appendNode("description", "Components that interact Onedrive")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("target", "3.9.2+")
-        properties.appendNode("tags", "azure,office365,outlook,exchange")
+        properties.appendNode("target", "3.11.1+")
+        properties.appendNode("tags", "azure,office365,onedrive")
         properties.appendNode("license", "false")
         properties.appendNode("readme", "https://github.com/adaptris/interlok-azure/raw/develop/README.md")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-azure")

--- a/interlok-azure-onedrive/build.gradle
+++ b/interlok-azure-onedrive/build.gradle
@@ -55,6 +55,8 @@ publishing {
         properties.appendNode("target", "3.9.2+")
         properties.appendNode("tags", "azure,office365,outlook,exchange")
         properties.appendNode("license", "false")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-azure/raw/develop/README.md")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-azure")
       }
     }
   }


### PR DESCRIPTION
## Motivation

Give the UI the ability to point to the optional component repository and to ensure that the README contains useful information.

## Modification

* Update the README so that it is useful
* Update the gradle.build files to include references to README and Git repository in the POM

## Result

The information will eventually be available in the UI

## Testing

Check that the new repository property exists in the POM file after running `gradle generatePomFileForMavenJavaPublication`

