### PR TITLE
Feature/interlok 3895 azure oauth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,6 @@ updates:
     allow:
       - dependency-type: "all"
     reviewers:
-      - quotidian-ennui
-      - mcwarman
       - aaron-mcgrath-adp
       - sebastien-belin-adp
       - higgyfella
@@ -30,8 +28,6 @@ updates:
     allow:
       - dependency-type: "all"
     reviewers:
-      - quotidian-ennui
-      - mcwarman
       - aaron-mcgrath-adp
       - sebastien-belin-adp
       - higgyfella

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,14 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
-  id 'com.github.spotbugs' version '5.0.7' apply false
-  id "io.freefair.lombok" version "6.4.3" apply false
-  id 'org.owasp.dependencycheck' version '7.1.0.1' apply false
+  id 'com.github.spotbugs' version '5.0.10' apply false
+  id "io.freefair.lombok" version "6.5.0.3" apply false
+  id 'org.owasp.dependencycheck' version '7.1.2' apply false
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '4.5-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '4.5-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '4.6-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '4.6-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"
@@ -22,7 +22,7 @@ ext {
 
   organizationName = "Adaptris Ltd"
   slf4jVersion = '1.7.36'
-  mockitoVersion = '4.5.1'
+  mockitoVersion = '4.7.0'
 
 }
 

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     exclude group: "com.google.code.gson", module: "gson"
     exclude group: "com.squareup.okhttp3", module: "okhttp"
   }
-  implementation ("com.google.code.gson:gson:2.9.1") {
+  implementation ("com.google.code.gson:gson:2.9.1")
   implementation ("com.squareup.okhttp3:okhttp:4.10.0") {
     exclude group: "com.google.code.gson", module: "gson"
     exclude group: "com.squareup.okio", module: "okio"

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         because "CVE-2021-27568: Affect json-smart up to (excluding) 2.3.1"
       }
     }
-  api ("com.microsoft.graph:microsoft-graph:2.5.0") {
+  api ("com.microsoft.graph:microsoft-graph:5.25.0") {
     exclude group: "com.google.code.gson", module: "gson"
   }
   implementation ("com.google.code.gson:gson:2.9.0")
@@ -37,6 +37,7 @@ dependencies {
   implementation ("io.netty:netty-codec:$nettyVersion")
   implementation ("io.netty:netty-codec-http2:$nettyVersion")
   implementation ("io.netty:netty-codec-http:$nettyVersion")
+  implementation ("io.netty:netty-resolver-dns:$nettyVersion")
 
   api ("org.codehaus.staxmate:stax2:2.1")
   api ("com.google.guava:guava:31.1-jre")

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     exclude group: "com.squareup.okhttp3", module: "okhttp"
   }
   implementation ("com.google.code.gson:gson:2.9.1") {
+  implementation ("com.squareup.okhttp3:okhttp:4.10.0") {
+    exclude group: "com.google.code.gson", module: "gson"
     exclude group: "com.squareup.okio", module: "okio"
   }
   implementation ("com.squareup.okio:okio:3.2.0")

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -105,7 +105,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", componentDesc)
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,office365,outlook,exchange")

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -3,29 +3,32 @@ ext {
   componentDesc = "Common components for interacting with Azure and Office 365"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   jacksonVersion = '2.13.3'
-  nettyVersion = '4.1.77.Final'
+  nettyVersion = '4.1.80.Final'
 }
 
 dependencies {
 
-  api ("com.microsoft.azure:msal4j:1.12.0")
+  api ("com.microsoft.azure:msal4j:1.13.0")
     constraints {
       api("net.minidev:json-smart:2.4.8") {
         because "CVE-2021-27568: Affect json-smart up to (excluding) 2.3.1"
       }
     }
-  api ("com.microsoft.graph:microsoft-graph:5.25.0") {
+  api ("com.microsoft.graph:microsoft-graph:5.30.0") {
     exclude group: "com.google.code.gson", module: "gson"
   }
-  implementation ("com.google.code.gson:gson:2.9.0")
-  api ("com.azure:azure-identity:1.5.1") {
+  implementation ("com.google.code.gson:gson:2.9.1") {
+    exclude group: "com.squareup.okio", module: "okio"
+  }
+  implementation ("com.squareup.okio:okio:3.2.0")
+  api ("com.azure:azure-identity:1.5.4") {
     // Exclude KeePassJava2 dependencies, because we don't care
     // If people want it, then can include it themselves.
     exclude group: "org.linguafranca.pwdb", module: "KeePassJava2"
     exclude group: "org.simpleframework", module: "simple-xml"
     exclude group: "io.netty"
   }
-  api ("com.azure:azure-storage-file-datalake:12.10.0") {
+  api ("com.azure:azure-storage-file-datalake:12.12.0") {
     exclude group: "io.netty"
   }
 
@@ -39,6 +42,7 @@ dependencies {
   implementation ("io.netty:netty-codec-http:$nettyVersion")
   implementation ("io.netty:netty-resolver-dns:$nettyVersion")
 
+  api ("org.codehaus.woodstox:stax2-api:4.2.1")
   api ("org.codehaus.staxmate:stax2:2.1")
   api ("com.google.guava:guava:31.1-jre")
   // azure-core via azure-identity has an explicit dependency on these jars,

--- a/interlok-azure-core/build.gradle
+++ b/interlok-azure-core/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         because "CVE-2021-27568: Affect json-smart up to (excluding) 2.3.1"
       }
     }
-  api ("com.microsoft.graph:microsoft-graph:5.30.0") {
+  api ("com.microsoft.graph:microsoft-graph:5.33.0") {
     exclude group: "com.google.code.gson", module: "gson"
   }
   implementation ("com.google.code.gson:gson:2.9.1") {

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
@@ -4,7 +4,6 @@ import javax.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
-import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisConnectionImp;
 import com.adaptris.core.CoreException;
@@ -20,7 +19,6 @@ import lombok.Setter;
 @XStreamAlias("azure-connection")
 @AdapterComponent
 @ComponentProfile(summary = "Connect to an Azure tenant", tag = "connections,azure")
-@DisplayOrder(order = { "applicationId", "tenantId", "clientSecret" })
 public abstract class AzureConnection<C> extends AdaptrisConnectionImp {
   /**
    * The ID of the Azure application.

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
@@ -1,5 +1,7 @@
 package com.adaptris.interlok.azure;
 
+import javax.validation.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -7,10 +9,9 @@ import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisConnectionImp;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.constraints.NotBlank;
 
 /**
  * Base Azure connection.
@@ -76,11 +77,6 @@ public abstract class AzureConnection<C> extends AdaptrisConnectionImp
   protected void closeConnection()
   {
     /* do nothing */
-  }
-
-  protected String tenant()
-  {
-    return String.format("https://login.microsoftonline.com/%s", tenantId);
   }
 
   protected String clientSecret()

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
@@ -51,7 +51,7 @@ public abstract class AzureConnection<C> extends AdaptrisConnectionImp {
    * {@inheritDoc}.
    */
   @Override
-  protected void prepareConnection() throws CoreException {
+  protected void prepareConnection() {
     /* do nothing */
   }
 

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
@@ -7,6 +7,7 @@ import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisConnectionImp;
+import com.adaptris.core.CoreException;
 import com.adaptris.interlok.resolver.ExternalResolver;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -20,8 +21,7 @@ import lombok.Setter;
 @AdapterComponent
 @ComponentProfile(summary = "Connect to an Azure tenant", tag = "connections,azure")
 @DisplayOrder(order = { "applicationId", "tenantId", "clientSecret" })
-public abstract class AzureConnection<C> extends AdaptrisConnectionImp
-{
+public abstract class AzureConnection<C> extends AdaptrisConnectionImp {
   /**
    * The ID of the Azure application.
    */
@@ -53,8 +53,7 @@ public abstract class AzureConnection<C> extends AdaptrisConnectionImp
    * {@inheritDoc}.
    */
   @Override
-  protected void prepareConnection()
-  {
+  protected void prepareConnection() throws CoreException {
     /* do nothing */
   }
 
@@ -62,8 +61,7 @@ public abstract class AzureConnection<C> extends AdaptrisConnectionImp
    * {@inheritDoc}.
    */
   @Override
-  protected void stopConnection()
-  {
+  protected void stopConnection() {
     /* do nothing */
   }
 
@@ -74,13 +72,11 @@ public abstract class AzureConnection<C> extends AdaptrisConnectionImp
    * Close the underlying connection.
    */
   @Override
-  protected void closeConnection()
-  {
+  protected void closeConnection() {
     /* do nothing */
   }
 
-  protected String clientSecret()
-  {
+  protected String clientSecret() {
     return ExternalResolver.resolve(clientSecret);
   }
 }

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
@@ -1,5 +1,7 @@
 package com.adaptris.interlok.azure;
 
+import javax.validation.constraints.NotBlank;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.CoreException;
@@ -8,10 +10,9 @@ import com.azure.identity.ClientSecretCredentialBuilder;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.constraints.NotBlank;
 
 @XStreamAlias("azure-data-lake-connection")
 @AdapterComponent
@@ -41,7 +42,7 @@ public class DataLakeConnection extends AzureConnection<DataLakeServiceClient>
       clientSecretCredential = new ClientSecretCredentialBuilder()
           .clientId(applicationId)
           .clientSecret(clientSecret())
-          .tenantId(tenantId)
+          .tenantId(getTenantId())
           .build();
     }
     catch (Exception e)
@@ -65,6 +66,7 @@ public class DataLakeConnection extends AzureConnection<DataLakeServiceClient>
   @Override
   public DataLakeServiceClient getClientConnection()
   {
+    // Should we createt the client in startConnection?
     return new DataLakeServiceClientBuilder().credential(clientSecretCredential).endpoint(String.format("https://%s.dfs.core.windows.net", account)).buildClient();
   }
 }

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.CoreException;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
@@ -17,6 +18,7 @@ import lombok.Setter;
 @XStreamAlias("azure-data-lake-connection")
 @AdapterComponent
 @ComponentProfile(summary = "Connect to an Azure tenant and access the Data Lake", tag = "connections,azure,data lake,data,lake")
+@DisplayOrder(order = { "applicationId", "tenantId", "clientSecret" })
 public class DataLakeConnection extends AzureConnection<DataLakeServiceClient> {
   /**
    * The Azure account to use to access the Data Lake.

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
@@ -17,8 +17,7 @@ import lombok.Setter;
 @XStreamAlias("azure-data-lake-connection")
 @AdapterComponent
 @ComponentProfile(summary = "Connect to an Azure tenant and access the Data Lake", tag = "connections,azure,data lake,data,lake")
-public class DataLakeConnection extends AzureConnection<DataLakeServiceClient>
-{
+public class DataLakeConnection extends AzureConnection<DataLakeServiceClient> {
   /**
    * The Azure account to use to access the Data Lake.
    */
@@ -28,25 +27,20 @@ public class DataLakeConnection extends AzureConnection<DataLakeServiceClient>
   private String account;
 
   private transient ClientSecretCredential clientSecretCredential;
+  private transient DataLakeServiceClient clientConnection;
 
   /**
    * Initialise the underlying connection.
    *
-   * @throws CoreException wrapping any exception.
+   * @throws CoreException
+   *           wrapping any exception.
    */
   @Override
-  protected void initConnection() throws CoreException
-  {
-    try
-    {
-      clientSecretCredential = new ClientSecretCredentialBuilder()
-          .clientId(applicationId)
-          .clientSecret(clientSecret())
-          .tenantId(getTenantId())
-          .build();
-    }
-    catch (Exception e)
-    {
+  protected void initConnection() throws CoreException {
+    try {
+      clientSecretCredential = new ClientSecretCredentialBuilder().clientId(applicationId).clientSecret(clientSecret())
+          .tenantId(getTenantId()).build();
+    } catch (Exception e) {
       log.error("Could not identify Azure application or tenant", e);
       throw new CoreException(e);
     }
@@ -55,18 +49,18 @@ public class DataLakeConnection extends AzureConnection<DataLakeServiceClient>
   /**
    * Start the underlying connection.
    *
-   * @throws CoreException wrapping any exception.
+   * @throws CoreException
+   *           wrapping any exception.
    */
   @Override
-  protected void startConnection()
-  {
-    /* do nothing */
+  protected void startConnection() {
+    clientConnection = new DataLakeServiceClientBuilder().credential(clientSecretCredential)
+        .endpoint(String.format("https://%s.dfs.core.windows.net", account)).buildClient();
   }
 
   @Override
-  public DataLakeServiceClient getClientConnection()
-  {
-    // Should we createt the client in startConnection?
-    return new DataLakeServiceClientBuilder().credential(clientSecretCredential).endpoint(String.format("https://%s.dfs.core.windows.net", account)).buildClient();
+  public DataLakeServiceClient getClientConnection() {
+    // Should we create the client in startConnection?
+    return clientConnection;
   }
 }

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/GraphAPIConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/GraphAPIConnection.java
@@ -28,9 +28,12 @@ public class GraphAPIConnection extends AzureConnection<GraphServiceClient<?>> {
   @Override
   protected void initConnection() throws CoreException {
     try {
-      ClientSecretCredential tokenCredential = new ClientSecretCredentialBuilder().clientId(applicationId).clientSecret(clientSecret())
-          .tenantId(getTenantId()).build();
-      tokenCredentialAuthProvider = new TokenCredentialAuthProvider(Collections.singletonList(SCOPE), tokenCredential);
+      ClientSecretCredential clientSecretCredential = new ClientSecretCredentialBuilder()
+          .clientId(applicationId)
+          .clientSecret(clientSecret())
+          .tenantId(getTenantId())
+          .build();
+      tokenCredentialAuthProvider = new TokenCredentialAuthProvider(Collections.singletonList(SCOPE), clientSecretCredential);
     } catch (Exception e) {
       log.error("Could not identify Azure application or tenant", e);
       throw new CoreException(e);

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/GraphAPIConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/GraphAPIConnection.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.CoreException;
 import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
@@ -17,6 +18,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("azure-graph-api-connection")
 @AdapterComponent
 @ComponentProfile(summary = "Connect to an Azure tenant and access the Graph API", tag = "connections,azure,graph api,graph")
+@DisplayOrder(order = { "applicationId", "tenantId", "clientSecret" })
 public class GraphAPIConnection extends AzureConnection<GraphServiceClient<?>> {
 
   // TODO Should we let the user the ability to change the scope?

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/GraphAPIConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/GraphAPIConnection.java
@@ -1,17 +1,15 @@
 package com.adaptris.interlok.azure;
 
+import java.util.Collections;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.core.CoreException;
-import com.microsoft.aad.msal4j.ClientCredentialFactory;
-import com.microsoft.aad.msal4j.ClientCredentialParameters;
-import com.microsoft.aad.msal4j.ConfidentialClientApplication;
-import com.microsoft.aad.msal4j.IAuthenticationResult;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.requests.extensions.GraphServiceClient;
+import com.azure.identity.ClientSecretCredential;
+import com.azure.identity.ClientSecretCredentialBuilder;
+import com.microsoft.graph.authentication.TokenCredentialAuthProvider;
+import com.microsoft.graph.requests.GraphServiceClient;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import java.util.Collections;
 
 /**
  * Azure connection to use the Graph API.
@@ -19,60 +17,34 @@ import java.util.Collections;
 @XStreamAlias("azure-graph-api-connection")
 @AdapterComponent
 @ComponentProfile(summary = "Connect to an Azure tenant and access the Graph API", tag = "connections,azure,graph api,graph")
-public class GraphAPIConnection extends AzureConnection<IGraphServiceClient>
-{
+public class GraphAPIConnection extends AzureConnection<GraphServiceClient<?>> {
+
+  // TODO Should we let the user the ability to change the scope?
   private static final String SCOPE = "https://graph.microsoft.com/.default";
 
-  private transient ConfidentialClientApplication confidentialClientApplication;
+  private transient TokenCredentialAuthProvider tokenCredentialAuthProvider;
+  private transient GraphServiceClient<?> clientConnection;
 
-  private transient String accessToken;
-
-  /**
-   * Initialise the underlying connection.
-   *
-   * @throws CoreException wrapping any exception.
-   */
   @Override
-  protected void initConnection() throws CoreException
-  {
-    try
-    {
-      confidentialClientApplication = ConfidentialClientApplication.builder(applicationId,
-          ClientCredentialFactory.createFromSecret(clientSecret()))
-          .authority(tenant())
-          .build();
-    }
-    catch (Exception e)
-    {
+  protected void initConnection() throws CoreException {
+    try {
+      ClientSecretCredential tokenCredential = new ClientSecretCredentialBuilder().clientId(applicationId).clientSecret(clientSecret())
+          .tenantId(getTenantId()).build();
+      tokenCredentialAuthProvider = new TokenCredentialAuthProvider(Collections.singletonList(SCOPE), tokenCredential);
+    } catch (Exception e) {
       log.error("Could not identify Azure application or tenant", e);
       throw new CoreException(e);
     }
   }
 
-  /**
-   * Start the underlying connection.
-   *
-   * @throws CoreException wrapping any exception.
-   */
   @Override
-  protected void startConnection() throws CoreException
-  {
-    try
-    {
-      IAuthenticationResult iAuthResult = confidentialClientApplication.acquireToken(ClientCredentialParameters.builder(Collections.singleton(SCOPE)).build()).join();
-      accessToken = iAuthResult.accessToken();
-    }
-    catch (Exception e)
-    {
-      log.error("Could not acquire access token", e);
-      throw new CoreException(e);
-    }
+  protected void startConnection() throws CoreException {
+    clientConnection = GraphServiceClient.builder().authenticationProvider(tokenCredentialAuthProvider).buildClient();
   }
 
   @Override
-  public IGraphServiceClient getClientConnection()
-  {
-    return GraphServiceClient.builder().authenticationProvider(request -> request.addHeader("Authorization", "Bearer " + accessToken)).buildClient();
+  public GraphServiceClient<?> getClientConnection() {
+    return clientConnection;
   }
 
 }

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/ResourceTypeHelper.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/ResourceTypeHelper.java
@@ -1,25 +1,27 @@
 package com.adaptris.interlok.azure.cosmosdb;
 
-import com.microsoft.azure.documentdb.internal.Paths;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.SneakyThrows;
-import org.apache.commons.lang3.BooleanUtils;
-
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.net.URL;
-import java.util.Arrays;
-
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.stripEnd;
 import static org.apache.commons.lang3.StringUtils.stripStart;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URL;
+import java.util.Arrays;
+
+import org.apache.commons.lang3.BooleanUtils;
+
+import com.microsoft.azure.documentdb.internal.Paths;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+
 /**
  * This is to assist the UI with type-ahead on the ResourceTypes/ResourceSegments
- * 
+ *
  */
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ResourceTypeHelper {
@@ -37,7 +39,7 @@ public class ResourceTypeHelper {
 
   /**
    * Used by the InputFieldHint annotation for type-ahead.
-   * 
+   *
    */
   public static String[] getResourceTypes() {
     return Arrays.copyOf(declaredConstants, declaredConstants.length);
@@ -55,13 +57,14 @@ public class ResourceTypeHelper {
    * <p>
    * Odd number of uri fragments, it's the last one, even number of uri fragments it's the penultimate one.
    * <ul>
-   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/ -> docs</li>
-   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -> docs</li>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/ -&gt; docs</li>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -&gt; docs</li>
    * <li>
    * </ul>
    * </p>
-   * 
-   * @param url the URL endpoint
+   *
+   * @param url
+   *          the URL endpoint
    * @return the ResourceType
    * @see CosmosAuthorizationHeaderFromUrl
    */
@@ -82,13 +85,14 @@ public class ResourceTypeHelper {
    * <p>
    * odd number of uri fragments, then it's everything but the last one; even number of uri fragments it's all of them.
    * <ul>
-   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls -> dbs/tempdb</li>
-   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -> dbs/tempdb/colls/tempcoll/docs/MyName</li>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls -&gt; dbs/tempdb</li>
+   * <li>https://azuredb.microsoft.com/dbs/tempdb/colls/tempcoll/docs/MyName -&gt; dbs/tempdb/colls/tempcoll/docs/MyName</li>
    * <li>
    * </ul>
    * </p>
-   * 
-   * @param url the URL endpoint
+   *
+   * @param url
+   *          the URL endpoint
    * @return the ResourceID.
    * @see CosmosAuthorizationHeaderFromUrl
    */

--- a/interlok-azure-datalake/build.gradle
+++ b/interlok-azure-datalake/build.gradle
@@ -52,7 +52,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", componentDesc)
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,data lake,data,lake")

--- a/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeConsumer.java
+++ b/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeConsumer.java
@@ -12,9 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.interlok.azure.datalake;
+
+import java.io.OutputStream;
+
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.io.FilenameUtils;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
@@ -31,16 +37,12 @@ import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.azure.storage.file.datalake.models.ListPathsOptions;
 import com.azure.storage.file.datalake.models.PathItem;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.io.FilenameUtils;
-
-import javax.validation.constraints.NotBlank;
-import java.io.OutputStream;
 
 /**
- * Implementation of a file consumer that can retrieve files from
- * Microsoft Data Lake.
+ * Implementation of a file consumer that can retrieve files from Microsoft Data Lake.
  *
  * @config azure-data-lake-consumer
  */
@@ -48,8 +50,7 @@ import java.io.OutputStream;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup data frmo Azure Data Lake", tag = "consumer,azure,data lake,data,lake")
 @DisplayOrder(order = { "fileSystem", "path" })
-public class DataLakeConsumer extends AdaptrisPollingConsumer
-{
+public class DataLakeConsumer extends AdaptrisPollingConsumer {
   /**
    * The Data Lake file system to access.
    */
@@ -70,8 +71,7 @@ public class DataLakeConsumer extends AdaptrisPollingConsumer
    * {@inheritDoc}.
    */
   @Override
-  protected void prepareConsumer()
-  {
+  protected void prepareConsumer() {
     /* do nothing */
   }
 
@@ -81,13 +81,11 @@ public class DataLakeConsumer extends AdaptrisPollingConsumer
    * @return The number of files found.
    */
   @Override
-  protected int processMessages()
-  {
+  protected int processMessages() {
     log.debug("Polling for data in Azure Data Lake");
 
     int count = 0;
-    try
-    {
+    try {
       DataLakeConnection connection = retrieveConnection(DataLakeConnection.class);
 
       log.debug("Scanning {}:{} for files", fileSystem, path);
@@ -99,11 +97,9 @@ public class DataLakeConsumer extends AdaptrisPollingConsumer
       ListPathsOptions options = new ListPathsOptions();
       options.setPath(path);
       PagedIterable<PathItem> pagedIterable = fileSystemClient.listPaths(options, null);
-      for (PathItem item : pagedIterable)
-      {
+      for (PathItem item : pagedIterable) {
         String name = FilenameUtils.getName(item.getName());
-        if (item.isDirectory())
-        {
+        if (item.isDirectory()) {
           log.debug("Skipping directory {}", name);
         }
         log.debug("Found file {}", name);
@@ -114,8 +110,7 @@ public class DataLakeConsumer extends AdaptrisPollingConsumer
 
         DataLakeFileClient fileClient = directoryClient.getFileClient(name);
 
-        try (OutputStream os = message.getOutputStream())
-        {
+        try (OutputStream os = message.getOutputStream()) {
           fileClient.read(os);
         }
 
@@ -123,9 +118,7 @@ public class DataLakeConsumer extends AdaptrisPollingConsumer
       }
 
       count++;
-    }
-    catch (Throwable e)
-    {
+    } catch (Throwable e) {
       log.error("Exception in Data Lake", e);
     }
 
@@ -136,11 +129,8 @@ public class DataLakeConsumer extends AdaptrisPollingConsumer
    * {@inheritDoc}.
    */
   @Override
-  protected String newThreadName()
-  {
+  protected String newThreadName() {
     return DestinationHelper.threadName(retrieveAdaptrisMessageListener(), null);
   }
 
-
 }
-

--- a/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeProducer.java
+++ b/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeProducer.java
@@ -1,5 +1,11 @@
 package com.adaptris.interlok.azure.datalake;
 
+import java.io.InputStream;
+
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -15,14 +21,9 @@ import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.BooleanUtils;
-
-import javax.validation.constraints.NotBlank;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Implementation of a file producer that can upload files to Microsoft

--- a/interlok-azure-mail/build.gradle
+++ b/interlok-azure-mail/build.gradle
@@ -52,7 +52,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", componentDesc)
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,office365,outlook,exchange")

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
@@ -121,7 +121,6 @@ public class O365MailConsumer extends AdaptrisPollingConsumer {
    */
   @Override
   protected void prepareConsumer() {
-    /* Do nothing */
   }
 
   /**
@@ -146,7 +145,7 @@ public class O365MailConsumer extends AdaptrisPollingConsumer {
 
       for (Message outlookMessage : currentPage) {
         String id = outlookMessage.id;
-        AdaptrisMessage adaptrisMessage = getMessageFactory().newMessage(outlookMessage.body.content);
+        AdaptrisMessage adaptrisMessage = decode(outlookMessage.body.content.getBytes());
 
         if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage) {
           ((MultiPayloadAdaptrisMessage) adaptrisMessage).setCurrentPayloadId(id);

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.interlok.azure.mail;
 
+import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import java.io.ByteArrayInputStream;
@@ -146,7 +147,8 @@ public class O365MailConsumer extends AdaptrisPollingConsumer {
 
       for (Message outlookMessage : currentPage) {
         String id = outlookMessage.id;
-        AdaptrisMessage adaptrisMessage = decode(outlookMessage.body.content.getBytes());
+        AdaptrisMessage adaptrisMessage = decode(
+            outlookMessage.body.content.getBytes(defaultIfNull(getMessageFactory()).getDefaultCharEncoding()));
 
         if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage) {
           ((MultiPayloadAdaptrisMessage) adaptrisMessage).setCurrentPayloadId(id);

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
@@ -20,6 +20,7 @@ import static com.adaptris.core.AdaptrisMessageFactory.defaultIfNull;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -148,7 +149,7 @@ public class O365MailConsumer extends AdaptrisPollingConsumer {
       for (Message outlookMessage : currentPage) {
         String id = outlookMessage.id;
         AdaptrisMessage adaptrisMessage = decode(
-            outlookMessage.body.content.getBytes(defaultIfNull(getMessageFactory()).getDefaultCharEncoding()));
+            outlookMessage.body.content.getBytes(charset()));
 
         if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage) {
           ((MultiPayloadAdaptrisMessage) adaptrisMessage).setCurrentPayloadId(id);
@@ -239,6 +240,10 @@ public class O365MailConsumer extends AdaptrisPollingConsumer {
 
   private String joinEmailAddresses(List<Recipient> recipients) {
     return CollectionUtils.emptyIfNull(recipients).stream().map(r -> r.emailAddress.address).collect(Collectors.joining(","));
+  }
+
+  private String charset() {
+    return StringUtils.defaultIfBlank(defaultIfNull(getMessageFactory()).getDefaultCharEncoding(), Charset.defaultCharset().name());
   }
 
   /**

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
@@ -121,6 +121,7 @@ public class O365MailConsumer extends AdaptrisPollingConsumer {
    */
   @Override
   protected void prepareConsumer() {
+    /* do nothing */
   }
 
   /**

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
@@ -12,9 +12,27 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.interlok.azure.mail;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.mail.BodyPart;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMultipart;
+import javax.mail.util.ByteArrayDataSource;
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
@@ -27,33 +45,22 @@ import com.adaptris.core.AdaptrisPollingConsumer;
 import com.adaptris.core.MultiPayloadAdaptrisMessage;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.microsoft.graph.models.extensions.Attachment;
-import com.microsoft.graph.models.extensions.FileAttachment;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.models.extensions.InternetMessageHeader;
-import com.microsoft.graph.models.extensions.Message;
-import com.microsoft.graph.requests.extensions.IAttachmentCollectionPage;
-import com.microsoft.graph.requests.extensions.IAttachmentRequest;
-import com.microsoft.graph.requests.extensions.IMessageCollectionPage;
+import com.microsoft.graph.models.Attachment;
+import com.microsoft.graph.models.FileAttachment;
+import com.microsoft.graph.models.InternetMessageHeader;
+import com.microsoft.graph.models.Message;
+import com.microsoft.graph.models.Recipient;
+import com.microsoft.graph.requests.AttachmentCollectionPage;
+import com.microsoft.graph.requests.AttachmentRequest;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.MessageCollectionPage;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.mail.BodyPart;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
-import javax.validation.constraints.NotBlank;
-import java.io.ByteArrayInputStream;
-import java.util.Base64;
-
-import static java.nio.charset.StandardCharsets.US_ASCII;
 
 /**
- * Implementation of an email consumer that is geared towards Microsoft
- * Office 365, using their Graph API and OAuth2.
+ * Implementation of an email consumer that is geared towards Microsoft Office 365, using their Graph API and OAuth2.
  *
  * @config azure-office-365-mail-consumer
  */
@@ -61,8 +68,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup email from a Microsoft Office 365 account using the Microsoft Graph API", tag = "consumer,email,o365,microsoft,office,outlook,365")
 @DisplayOrder(order = { "username", "delete" })
-public class O365MailConsumer extends AdaptrisPollingConsumer
-{
+public class O365MailConsumer extends AdaptrisPollingConsumer {
   static final String DEFAULT_FOLDER = "inbox";
 
   static final String DEFAULT_FILTER = "isRead eq false";
@@ -100,8 +106,8 @@ public class O365MailConsumer extends AdaptrisPollingConsumer
   /**
    * How to filter the messages.
    *
-   * The default filter is 'isRead eq false'. See https://docs.microsoft.com/en-us/graph/query-parameters#filter-parameter
-   * for further filter parameters.
+   * The default filter is 'isRead eq false'. See https://docs.microsoft.com/en-us/graph/query-parameters#filter-parameter for further
+   * filter parameters.
    */
   @Getter
   @Setter
@@ -110,14 +116,12 @@ public class O365MailConsumer extends AdaptrisPollingConsumer
   @InputFieldDefault(DEFAULT_FILTER)
   private String filter;
 
-
   /**
    * {@inheritDoc}.
    */
   @Override
-  protected void prepareConsumer()
-  {
-    /* do nothing */
+  protected void prepareConsumer() {
+    /* Do nothing */
   }
 
   /**
@@ -126,90 +130,48 @@ public class O365MailConsumer extends AdaptrisPollingConsumer
    * @return The number of new emails received.
    */
   @Override
-  protected int processMessages()
-  {
+  protected int processMessages() {
     log.debug("Polling for mail in Office365 as user " + username);
 
     int count = 0;
-    try
-    {
+    try {
       GraphAPIConnection connection = retrieveConnection(GraphAPIConnection.class);
-      IGraphServiceClient graphClient = connection.getClientConnection();
+      GraphServiceClient<?> graphClient = connection.getClientConnection();
 
-      // TODO Allow the end user to choose the folder and filter themselves
-      IMessageCollectionPage messages = graphClient.users(username).mailFolders(folder()).messages().buildRequest().filter(filter()).get();
+      MessageCollectionPage messages = graphClient.users(username).mailFolders(folder()).messages().buildRequest().filter(filter()).get();
 
       // TODO handle multiple pages...
-      log.debug("Found {} messages", messages.getCurrentPage().size());
-      for (Message outlookMessage : messages.getCurrentPage())
-      {
+      List<Message> currentPage = messages.getCurrentPage();
+      log.debug("Found {} messages", currentPage.size());
+
+      for (Message outlookMessage : currentPage) {
         String id = outlookMessage.id;
         AdaptrisMessage adaptrisMessage = getMessageFactory().newMessage(outlookMessage.body.content);
 
-        if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage)
-        {
-          ((MultiPayloadAdaptrisMessage)adaptrisMessage).setCurrentPayloadId(id);
+        if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage) {
+          ((MultiPayloadAdaptrisMessage) adaptrisMessage).setCurrentPayloadId(id);
         }
-        adaptrisMessage.addMetadata("EmailID", id);
-        adaptrisMessage.addMetadata("Subject", outlookMessage.subject);
-        adaptrisMessage.addMetadata("To", outlookMessage.toRecipients.stream().map(r -> r.emailAddress.address).reduce((a, b) -> a + "," + b).get() );
-        adaptrisMessage.addMetadata("From", outlookMessage.from.emailAddress.address);
-        adaptrisMessage.addMetadata("CC", String.join(",", outlookMessage.ccRecipients.stream().map(r -> r.emailAddress.address).toArray(String[]::new)));
+
+        addMessageMetadata(outlookMessage, id, adaptrisMessage);
 
         log.debug("Processing email from {}: {}", outlookMessage.from.emailAddress.address, outlookMessage.subject);
 
-        if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage && outlookMessage.hasAttachments)
-        {
-          MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = (MultiPayloadAdaptrisMessage)adaptrisMessage;
-          IAttachmentCollectionPage attachments = graphClient.users(username).messages(id).attachments().buildRequest().get();
-          log.debug("Message has {} attachments", attachments.getCurrentPage().size());
-          for (Attachment reference : attachments.getCurrentPage())
-          {
-            log.debug("Attachment {} is of type {} with size {}", reference.name, reference.oDataType, reference.size);
-            IAttachmentRequest request = graphClient.users(username).messages(id).attachments(reference.id).buildRequest();//new QueryOption("value", ""));
-            log.debug("URL: {}", request.getRequestUrl());
-            Attachment attachment = request.get();
-            if (attachment instanceof FileAttachment)
-            {
-              FileAttachment file = (FileAttachment)attachment;
-              log.debug("File {} :: {} :: {}", file.name, file.contentType, file.size);
-              if (file.contentType.startsWith("multipart"))
-              {
-                MimeMultipart mimeMultipart = new MimeMultipart(new ByteArrayDataSource(file.contentBytes, file.contentType));
-                parseMimeMultiPart(multiPayloadAdaptrisMessage, mimeMultipart);
-              }
-              else
-              {
-                addAttachmentToAdaptrisMessage(multiPayloadAdaptrisMessage, file.name, file.contentBytes);
-              }
-            }
-          }
-          multiPayloadAdaptrisMessage.switchPayload(id);
+        if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage && outlookMessage.hasAttachments) {
+          processMultiPayload(graphClient, outlookMessage, id, adaptrisMessage);
         }
 
         /*
          * The internetMessageHeaders need to be requested explicitly with a SELECT.
          */
-        outlookMessage = graphClient.users(username).messages(id).buildRequest().select("internetMessageHeaders").get();
-        if (outlookMessage.internetMessageHeaders != null)
-        {
-          for (InternetMessageHeader header : outlookMessage.internetMessageHeaders)
-          {
-            adaptrisMessage.addMetadata(header.name, header.value);
-          }
-        }
+        outlookMessage = processInternetMessageHeaders(graphClient, id, adaptrisMessage);
 
         retrieveAdaptrisMessageListener().onAdaptrisMessage(adaptrisMessage);
 
-        if (delete())
-        {
+        if (delete()) {
           graphClient.users(username).messages(id).buildRequest().delete();
-        }
-        else
-        {
+        } else {
           /*
-           * With PATCH, only send what we've changed, in this instance
-           * we're marking the mail as read.
+           * With PATCH, only send what we've changed, in this instance we're marking the mail as read.
            */
           outlookMessage = new Message();
           outlookMessage.isRead = true;
@@ -219,90 +181,117 @@ public class O365MailConsumer extends AdaptrisPollingConsumer
         count++;
       }
 
-    }
-    catch (Throwable e)
-    {
+    } catch (Throwable e) {
       log.error("Exception processing Outlook message", e);
     }
 
     return count;
   }
 
+  private Message processInternetMessageHeaders(GraphServiceClient<?> graphClient, String id, AdaptrisMessage adaptrisMessage) {
+    Message outlookMessage;
+    outlookMessage = graphClient.users(username).messages(id).buildRequest().select("internetMessageHeaders").get();
+    if (outlookMessage.internetMessageHeaders != null) {
+      for (InternetMessageHeader header : outlookMessage.internetMessageHeaders) {
+        adaptrisMessage.addMetadata(header.name, header.value);
+      }
+    }
+    return outlookMessage;
+  }
+
+  private void processMultiPayload(GraphServiceClient<?> graphClient, Message outlookMessage, String id, AdaptrisMessage adaptrisMessage)
+      throws MessagingException, Exception {
+
+    MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = (MultiPayloadAdaptrisMessage) adaptrisMessage;
+    AttachmentCollectionPage attachments = graphClient.users(username).messages(id).attachments().buildRequest().get();
+    log.debug("Message has {} attachments", attachments.getCurrentPage().size());
+    for (Attachment reference : attachments.getCurrentPage()) {
+      log.debug("Attachment {} is of type {} with size {}", reference.name, reference.oDataType, reference.size);
+      AttachmentRequest request = graphClient.users(username).messages(id).attachments(reference.id).buildRequest();// new
+      // QueryOption("value",
+      // ""));
+      log.debug("URL: {}", request.getRequestUrl());
+      Attachment attachment = request.get();
+      if (attachment instanceof FileAttachment) {
+        FileAttachment file = (FileAttachment) attachment;
+        log.debug("File {} :: {} :: {}", file.name, file.contentType, file.size);
+        if (file.contentType.startsWith("multipart")) {
+          MimeMultipart mimeMultipart = new MimeMultipart(new ByteArrayDataSource(file.contentBytes, file.contentType));
+          parseMimeMultiPart(multiPayloadAdaptrisMessage, mimeMultipart);
+        } else {
+          addAttachmentToAdaptrisMessage(multiPayloadAdaptrisMessage, file.name, file.contentBytes);
+        }
+      }
+    }
+    multiPayloadAdaptrisMessage.switchPayload(id);
+  }
+
+  private void addMessageMetadata(Message outlookMessage, String id, AdaptrisMessage adaptrisMessage) {
+    adaptrisMessage.addMetadata("EmailID", id);
+    adaptrisMessage.addMetadata("Subject", outlookMessage.subject);
+    adaptrisMessage.addMetadata("To", joinEmailAddresses(outlookMessage.toRecipients));
+    adaptrisMessage.addMetadata("From", outlookMessage.from.emailAddress.address);
+    adaptrisMessage.addMetadata("CC", joinEmailAddresses(outlookMessage.ccRecipients));
+    adaptrisMessage.addMetadata("BCC", joinEmailAddresses(outlookMessage.bccRecipients));
+  }
+
+  private String joinEmailAddresses(List<Recipient> recipients) {
+    return CollectionUtils.emptyIfNull(recipients).stream().map(r -> r.emailAddress.address).collect(Collectors.joining(","));
+  }
+
   /**
    * {@inheritDoc}.
    */
   @Override
-  protected String newThreadName()
-  {
+  protected String newThreadName() {
     return DestinationHelper.threadName(retrieveAdaptrisMessageListener(), null);
   }
 
-  private boolean delete()
-  {
+  private boolean delete() {
     return BooleanUtils.toBooleanDefaultIfNull(delete, false);
   }
 
-  private String folder()
-  {
+  private String folder() {
     return StringUtils.defaultString(folder, DEFAULT_FOLDER);
   }
 
-  private String filter()
-  {
+  private String filter() {
     return StringUtils.defaultString(filter, DEFAULT_FILTER);
   }
 
-  private void addAttachmentToAdaptrisMessage(MultiPayloadAdaptrisMessage message, String name, byte[] attachment)
-  {
-    try
-    {
+  private void addAttachmentToAdaptrisMessage(MultiPayloadAdaptrisMessage message, String name, byte[] attachment) {
+    try {
       /*
-       * The Graph API documentation says that contentBytes
-       * is Base64 encoded, but that doesn't always appear to
-       * be the case
+       * The Graph API documentation says that contentBytes is Base64 encoded, but that doesn't always appear to be the case
        */
       attachment = Base64.getDecoder().decode(attachment);
-    }
-    catch (Exception e)
-    {
-      // do nothing; content wasn't base64 encoded
+    } catch (Exception e) {
+      // Do nothing; content wasn't base64 encoded
     }
     message.addPayload(name, attachment);
   }
 
-  private void parseMimeMultiPart(MultiPayloadAdaptrisMessage message, MimeMultipart mimeMultipart) throws Exception
-  {
-    for (int i = 0; i < mimeMultipart.getCount(); i++)
-    {
+  private void parseMimeMultiPart(MultiPayloadAdaptrisMessage message, MimeMultipart mimeMultipart) throws Exception {
+    for (int i = 0; i < mimeMultipart.getCount(); i++) {
       BodyPart bodyPart = mimeMultipart.getBodyPart(i);
       String name = bodyPart.getFileName();
       Object content = bodyPart.getContent();
-      if (content instanceof MimeMultipart)
-      {
-        parseMimeMultiPart(message, (MimeMultipart)content);
-      }
-      else if (name == null)
-      {
-        // do nothing; this is the email body
-      }
-      else
-      {
+      if (content instanceof MimeMultipart) {
+        parseMimeMultiPart(message, (MimeMultipart) content);
+      } else if (name == null) {
+        // Do nothing; this is the email body
+      } else {
         byte[] bytes = null;
-        if (content instanceof ByteArrayInputStream)
-        {
-          bytes = IOUtils.toByteArray((ByteArrayInputStream)content);
-        }
-        else if (content instanceof String)
-        {
-          bytes = ((String)content).getBytes(US_ASCII); // MIME encoded emails are always 7bit ASCII right??
-        }
-        else
-        {
+        if (content instanceof ByteArrayInputStream) {
+          bytes = IOUtils.toByteArray((ByteArrayInputStream) content);
+        } else if (content instanceof String) {
+          bytes = ((String) content).getBytes(US_ASCII); // MIME encoded emails are always 7bit ASCII right??
+        } else {
           log.warn("Unsupported MIME part {}", bodyPart.getContentType());
         }
         addAttachmentToAdaptrisMessage(message, name, bytes);
       }
     }
   }
-}
 
+}

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailProducer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailProducer.java
@@ -1,5 +1,15 @@
 package com.adaptris.interlok.azure.mail;
 
+import java.util.Base64;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -11,28 +21,21 @@ import com.adaptris.core.MultiPayloadAdaptrisMessage;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ProduceOnlyProducerImp;
 import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.microsoft.graph.models.extensions.EmailAddress;
-import com.microsoft.graph.models.extensions.FileAttachment;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.models.extensions.ItemBody;
-import com.microsoft.graph.models.extensions.Message;
-import com.microsoft.graph.models.extensions.Recipient;
-import com.microsoft.graph.models.generated.BodyType;
+import com.microsoft.graph.models.BodyType;
+import com.microsoft.graph.models.EmailAddress;
+import com.microsoft.graph.models.FileAttachment;
+import com.microsoft.graph.models.ItemBody;
+import com.microsoft.graph.models.Message;
+import com.microsoft.graph.models.Recipient;
+import com.microsoft.graph.models.UserSendMailParameterSet;
+import com.microsoft.graph.requests.GraphServiceClient;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.constraints.NotBlank;
-import java.util.Base64;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
- * Implementation of an email producer that is geared towards Microsoft
- * Office 365, using their Graph API and OAuth2.
+ * Implementation of an email producer that is geared towards Microsoft Office 365, using their Graph API and OAuth2.
  *
  * @config azure-office-365-mail-producer
  */
@@ -40,8 +43,7 @@ import java.util.List;
 @AdapterComponent
 @ComponentProfile(summary = "Send email using a Microsoft Office 365 account using the Microsoft Graph API", tag = "producer,email,o365,microsoft,office,outlook,365")
 @DisplayOrder(order = { "username", "subject", "toRecipients", "ccRecipients", "bccRecipients", "save" })
-public class O365MailProducer extends ProduceOnlyProducerImp
-{
+public class O365MailProducer extends ProduceOnlyProducerImp {
   /**
    * The Office 365 username of the mailbox to poll for new messages.
    */
@@ -96,33 +98,30 @@ public class O365MailProducer extends ProduceOnlyProducerImp
   @InputFieldDefault("true")
   private Boolean save;
 
-  /**
-   * {@inheritDoc}.
-   */
   @Override
-  public void prepare()
-  {
+  public void prepare() {
     /* do nothing */
   }
 
   /**
    * Send the given Adaptris message as an email.
    *
-   * @param adaptrisMessage The message to send.
-   * @param endpoint        Ignored.
-   * @throws ProduceException If there was a problem sending the email.
+   * @param adaptrisMessage
+   *          The message to send.
+   * @param endpoint
+   *          Ignored.
+   * @throws ProduceException
+   *           If there was a problem sending the email.
    */
   @Override
-  protected void doProduce(AdaptrisMessage adaptrisMessage, String endpoint) throws ProduceException
-  {
+  protected void doProduce(AdaptrisMessage adaptrisMessage, String endpoint) throws ProduceException {
     String user = adaptrisMessage.resolve(username);
 
     log.debug("Sending mail via Office365 as user " + user);
 
-    try
-    {
+    try {
       GraphAPIConnection connection = retrieveConnection(GraphAPIConnection.class);
-      IGraphServiceClient graphClient = connection.getClientConnection();
+      GraphServiceClient<?> graphClient = connection.getClientConnection();
 
       Message outlookMessage = new Message();
       outlookMessage.subject = adaptrisMessage.resolve(subject);
@@ -138,45 +137,28 @@ public class O365MailProducer extends ProduceOnlyProducerImp
 
       // TODO Add any custom headers.
 
-      if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage)
-      {
+      if (adaptrisMessage instanceof MultiPayloadAdaptrisMessage) {
         outlookMessage.isDraft = true;
         Message draftMessage = graphClient.users(user).messages().buildRequest().post(outlookMessage);
 
-        MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = (MultiPayloadAdaptrisMessage)adaptrisMessage;
+        MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage = (MultiPayloadAdaptrisMessage) adaptrisMessage;
         String id = multiPayloadAdaptrisMessage.getCurrentPayloadId();
-        for (String name : multiPayloadAdaptrisMessage.getPayloadIDs())
-        {
-          if (name.equals(id))
-          {
+        for (String name : multiPayloadAdaptrisMessage.getPayloadIDs()) {
+          if (name.equals(id)) {
             continue;
           }
           long size = multiPayloadAdaptrisMessage.getSize(name);
           /*
-           * Depending on the size of the file, you can choose one of
-           * two ways to attach a file to a message:
-           *  - If the file size is under 4 MB, you can do a single POST
-           *    on the attachments navigation property of the message.
-           *    The successful POST response includes the ID of the file
-           *    attached to the message.
-           *  - If the file size is between 3MB and 150MB, create an
-           *    upload session, and iteratively use PUT to upload ranges
-           *    of bytes of the file until you have uploaded the entire
-           *    file. A header in the final successful PUT response
-           *    includes a URL with the attachment ID.
+           * Depending on the size of the file, you can choose one of two ways to attach a file to a message: - If the file size is under 4
+           * MB, you can do a single POST on the attachments navigation property of the message. The successful POST response includes the
+           * ID of the file attached to the message. - If the file size is between 3MB and 150MB, create an upload session, and iteratively
+           * use PUT to upload ranges of bytes of the file until you have uploaded the entire file. A header in the final successful PUT
+           * response includes a URL with the attachment ID.
            */
-          if (size < 4 * FileUtils.ONE_MB)
-          {
-            FileAttachment attachment = new FileAttachment();
-            attachment.oDataType = "#microsoft.graph.fileAttachment";
-            attachment.name = name;
-            attachment.size = (int)size;
-            attachment.contentType = "application/octet-stream";
-            attachment.contentBytes = Base64.getEncoder().encode(multiPayloadAdaptrisMessage.getPayload(name));
+          if (size < 4 * FileUtils.ONE_MB) {
+            FileAttachment attachment = newAttachment(multiPayloadAdaptrisMessage, name, size);
             graphClient.users(user).messages(draftMessage.id).attachments().buildRequest().post(attachment);
-          }
-          else
-          {
+          } else {
             log.warn("Large attachments not yet supported!");
             /*
             AttachmentItem attachment = new AttachmentItem();
@@ -209,51 +191,56 @@ public class O365MailProducer extends ProduceOnlyProducerImp
               }
             });
              */
-           }
+          }
         }
         graphClient.users(user).messages(draftMessage.id).send().buildRequest().post();
+      } else {
+        UserSendMailParameterSet parameters = UserSendMailParameterSet.newBuilder().withMessage(outlookMessage).withSaveToSentItems(save())
+            .build();
+        graphClient.users(user).sendMail(parameters).buildRequest().post();
       }
-      else
-      {
-        graphClient.users(user).sendMail(outlookMessage, save()).buildRequest().post();
-      }
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       log.error("Exception processing Outlook message", e);
       throw new ProduceException(e);
     }
   }
 
-  /**
-   * {@inheritDoc}.
-   */
+  private FileAttachment newAttachment(MultiPayloadAdaptrisMessage multiPayloadAdaptrisMessage, String name, long size) {
+    FileAttachment attachment = new FileAttachment();
+    attachment.oDataType = "#microsoft.graph.fileAttachment";
+    attachment.name = name;
+    attachment.size = (int) size;
+    attachment.contentType = "application/octet-stream";
+    attachment.contentBytes = Base64.getEncoder().encode(multiPayloadAdaptrisMessage.getPayload(name));
+    return attachment;
+  }
+
   @Override
-  public String endpoint(AdaptrisMessage adaptrisMessage)
-  {
+  public String endpoint(AdaptrisMessage adaptrisMessage) {
     return adaptrisMessage.resolve(toRecipients);
   }
 
-  private static List<Recipient> resolveRecipients(AdaptrisMessage adaptrisMessage, String recipients)
-  {
-    if (StringUtils.isEmpty(recipients))
-    {
+  private static List<Recipient> resolveRecipients(AdaptrisMessage adaptrisMessage, String recipients) {
+    if (StringUtils.isEmpty(recipients)) {
       return null;
     }
     List<Recipient> recipientList = new LinkedList<>();
-    for (String address : adaptrisMessage.resolve(recipients).split(","))
-    {
-      Recipient recipient = new Recipient();
-      EmailAddress emailAddress = new EmailAddress();
-      emailAddress.address = address;
-      recipient.emailAddress = emailAddress;
-      recipientList.add(recipient);
+    for (String address : adaptrisMessage.resolve(recipients).split(",")) {
+      recipientList.add(newRecipient(address));
     }
     return recipientList;
   }
 
-  private boolean save()
-  {
+  private static Recipient newRecipient(String address) {
+    Recipient recipient = new Recipient();
+    EmailAddress emailAddress = new EmailAddress();
+    emailAddress.address = address;
+    recipient.emailAddress = emailAddress;
+    return recipient;
+  }
+
+  private boolean save() {
     return BooleanUtils.toBooleanDefaultIfNull(save, true);
   }
+
 }

--- a/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailProducerTest.java
+++ b/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailProducerTest.java
@@ -27,8 +27,7 @@ import com.microsoft.graph.requests.UserRequestBuilder;
 import com.microsoft.graph.requests.UserSendMailRequest;
 import com.microsoft.graph.requests.UserSendMailRequestBuilder;
 
-public class O365MailProducerTest extends ExampleProducerCase
-{
+public class O365MailProducerTest extends ExampleProducerCase {
   private static final String APPLICATION_ID = "47ea49b0-670a-47c1-9303-0b45ffb766ec";
   private static final String TENANT_ID = "cbf4a38d-3117-48cd-b54b-861480ee93cd";
   private static final String CLIENT_SECRET = "NGMyYjY0MTEtOTU0Ny00NTg0LWE3MzQtODg2ZDAzZGVmZmY1Cg==";
@@ -43,16 +42,12 @@ public class O365MailProducerTest extends ExampleProducerCase
   private boolean liveTests = false;
 
   @Before
-  public void setUp()
-  {
+  public void setUp() {
     Properties properties = new Properties();
-    try
-    {
+    try {
       properties.load(new FileInputStream(this.getClass().getResource("o365.properties").getFile()));
       liveTests = true;
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       // do nothing
     }
 
@@ -70,8 +65,7 @@ public class O365MailProducerTest extends ExampleProducerCase
   }
 
   @Test
-  public void testLiveProducer() throws Exception
-  {
+  public void testLiveProducer() throws Exception {
     Assume.assumeTrue(liveTests);
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
@@ -80,8 +74,7 @@ public class O365MailProducerTest extends ExampleProducerCase
   }
 
   @Test
-  public void testMockProducer() throws Exception
-  {
+  public void testMockProducer() throws Exception {
     Assume.assumeFalse(liveTests);
 
     connection = mock(GraphAPIConnection.class);
@@ -106,14 +99,12 @@ public class O365MailProducerTest extends ExampleProducerCase
   }
 
   @Override
-  protected Object retrieveObjectForSampleConfig()
-  {
+  protected Object retrieveObjectForSampleConfig() {
     return new StandaloneProducer(connection, producer);
   }
 
   @Override
-  protected List<StandaloneProducer> retrieveObjectsForSampleConfig()
-  {
-    return Collections.singletonList((StandaloneProducer)retrieveObjectForSampleConfig());
+  protected List<StandaloneProducer> retrieveObjectsForSampleConfig() {
+    return Collections.singletonList((StandaloneProducer) retrieveObjectForSampleConfig());
   }
 }

--- a/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailProducerTest.java
+++ b/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailProducerTest.java
@@ -1,33 +1,31 @@
 package com.adaptris.interlok.azure.mail;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.interlok.azure.AzureConnection;
-import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
-import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.models.extensions.Message;
-import com.microsoft.graph.requests.extensions.IUserRequestBuilder;
-import com.microsoft.graph.requests.extensions.IUserSendMailRequest;
-import com.microsoft.graph.requests.extensions.IUserSendMailRequestBuilder;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.FileInputStream;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.interlok.azure.GraphAPIConnection;
+import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+import com.microsoft.graph.models.UserSendMailParameterSet;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.UserRequestBuilder;
+import com.microsoft.graph.requests.UserSendMailRequest;
+import com.microsoft.graph.requests.UserSendMailRequestBuilder;
 
 public class O365MailProducerTest extends ExampleProducerCase
 {
@@ -39,7 +37,7 @@ public class O365MailProducerTest extends ExampleProducerCase
   private static final String SUBJECT = "InterlokMail Office365 Test Message";
   private static final String MESSAGE = "Bacon ipsum dolor amet tail landjaeger ribeye sausage, prosciutto pork belly strip steak pork loin pork bacon biltong ham hock leberkas boudin chicken. Brisket sirloin ground round, drumstick cupim rump chislic tongue short loin pastrami bresaola pork belly alcatra spare ribs buffalo. Swine chuck frankfurter pancetta. Corned beef spare ribs pork kielbasa, chuck jerky t-bone ground round burgdoggen.";
 
-  private AzureConnection connection;
+  private GraphAPIConnection connection;
   private O365MailProducer producer;
 
   private boolean liveTests = false;
@@ -90,14 +88,14 @@ public class O365MailProducerTest extends ExampleProducerCase
     producer.registerConnection(connection);
 
     when(connection.retrieveConnection(any())).thenReturn(connection);
-    IGraphServiceClient client = mock(IGraphServiceClient.class);
+    GraphServiceClient client = mock(GraphServiceClient.class);
     when(connection.getClientConnection()).thenReturn(client);
 
-    IUserRequestBuilder userRequestBuilder = mock(IUserRequestBuilder.class);
+    UserRequestBuilder userRequestBuilder = mock(UserRequestBuilder.class);
     when(client.users(USERNAME)).thenReturn(userRequestBuilder);
-    IUserSendMailRequestBuilder sendMailBuilder = mock(IUserSendMailRequestBuilder.class);
-    when(userRequestBuilder.sendMail(any(Message.class), anyBoolean())).thenReturn(sendMailBuilder);
-    IUserSendMailRequest messageRequest = mock(IUserSendMailRequest.class);
+    UserSendMailRequestBuilder sendMailBuilder = mock(UserSendMailRequestBuilder.class);
+    when(userRequestBuilder.sendMail(any(UserSendMailParameterSet.class))).thenReturn(sendMailBuilder);
+    UserSendMailRequest messageRequest = mock(UserSendMailRequest.class);
     when(sendMailBuilder.buildRequest()).thenReturn(messageRequest);
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);

--- a/interlok-azure-onedrive/build.gradle
+++ b/interlok-azure-onedrive/build.gradle
@@ -52,7 +52,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", componentDesc)
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.11.1+")
         properties.appendNode("tags", "azure,office365,onedrive")

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentDownloadService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentDownloadService.java
@@ -1,5 +1,14 @@
 package com.adaptris.interlok.azure.onedrive;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.apache.commons.io.IOUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -12,20 +21,14 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.microsoft.graph.models.extensions.Drive;
-import com.microsoft.graph.models.extensions.DriveItem;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
+import com.microsoft.graph.models.Drive;
+import com.microsoft.graph.models.DriveItem;
 import com.microsoft.graph.options.Option;
+import com.microsoft.graph.requests.GraphServiceClient;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.io.IOUtils;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
 
 /**
  * Retrieve the contents of a file from OneDrive.
@@ -34,10 +37,10 @@ import java.util.List;
  */
 @XStreamAlias("azure-one-drive-document-download-service")
 @AdapterComponent
-@ComponentProfile(summary = "Retrieve the contents of a file from OneDrive.", tag = "file,o365,microsoft,office,365,one drive,download", recommended = { GraphAPIConnection.class })
+@ComponentProfile(summary = "Retrieve the contents of a file from OneDrive.", tag = "file,o365,microsoft,office,365,one drive,download", recommended = {
+    GraphAPIConnection.class })
 @DisplayOrder(order = { "connection", "username", "filename" })
-public class DocumentDownloadService extends ServiceImp implements ConnectedService
-{
+public class DocumentDownloadService extends ServiceImp implements ConnectedService {
   /**
    * Connection to Azure OneDrive.
    */
@@ -66,43 +69,39 @@ public class DocumentDownloadService extends ServiceImp implements ConnectedServ
   private String filename;
 
   /**
-   * Any request options. Used in the transform service to set the
-   * output format. The Azure BaseRequest handles null or an empty
-   * list the same.
+   * Any request options. Used in the transform service to set the output format. The Azure BaseRequest handles null or an empty list the
+   * same.
    */
   protected List<Option> requestOptions;
 
   /**
    * Retrieve the contents of a file from OneDrive.
    *
-   * @param adaptrisMessage the <code>AdaptrisMessage</code> to process
-   * @throws ServiceException wrapping any underlying <code>Exception</code>s
+   * @param adaptrisMessage
+   *          the <code>AdaptrisMessage</code> to process
+   * @throws ServiceException
+   *           wrapping any underlying <code>Exception</code>s
    */
   @Override
-  public void doService(AdaptrisMessage adaptrisMessage) throws ServiceException
-  {
+  public void doService(AdaptrisMessage adaptrisMessage) throws ServiceException {
     String user = adaptrisMessage.resolve(username);
     String file = adaptrisMessage.resolve(filename);
 
-    try
-    {
-      IGraphServiceClient graphClient = ((GraphAPIConnection)connection).getClientConnection();
+    try {
+      GraphServiceClient graphClient = ((GraphAPIConnection) connection).getClientConnection();
 
       Drive oneDrive = graphClient.users(username).drive().buildRequest().get();
       DriveItem driveItem = graphClient.users(user).drives(oneDrive.id).root().itemWithPath(file).buildRequest().get();
 
-      try (InputStream remoteStream = graphClient.users(username).drives(oneDrive.id).items(driveItem.id).content().buildRequest(requestOptions).get())
-      {
-        try (OutputStream outputStream = adaptrisMessage.getOutputStream())
-        {
+      try (InputStream remoteStream = graphClient.users(username).drives(oneDrive.id).items(driveItem.id).content()
+          .buildRequest(requestOptions).get()) {
+        try (OutputStream outputStream = adaptrisMessage.getOutputStream()) {
           IOUtils.copy(remoteStream, outputStream);
         }
       }
 
       adaptrisMessage.addMetadata("filename", driveItem.name);
-    }
-    catch (Throwable e)
-    {
+    } catch (Throwable e) {
       log.error("Exception processing One Drive file", e);
       throw new ServiceException(e);
     }
@@ -111,11 +110,11 @@ public class DocumentDownloadService extends ServiceImp implements ConnectedServ
   /**
    * Calls LifecycleHelper#prepare for the Azure connection.
    *
-   * @throws CoreException If teh connection could not be prepared.
+   * @throws CoreException
+   *           If teh connection could not be prepared.
    */
   @Override
-  public void prepare() throws CoreException
-  {
+  public void prepare() throws CoreException {
     LifecycleHelper.prepare(connection);
   }
 
@@ -123,19 +122,18 @@ public class DocumentDownloadService extends ServiceImp implements ConnectedServ
    * Calls LifecycleHelper#init for the Azure connection.
    */
   @Override
-  protected void initService() throws CoreException
-  {
+  protected void initService() throws CoreException {
     LifecycleHelper.init(connection);
   }
 
   /**
    * Calls LifecycleHelper#start for the Azure connection.
    *
-   * @throws CoreException If teh connection could not be prepared.
+   * @throws CoreException
+   *           If teh connection could not be prepared.
    */
   @Override
-  public void start() throws CoreException
-  {
+  public void start() throws CoreException {
     super.start();
     LifecycleHelper.start(connection);
   }
@@ -144,8 +142,7 @@ public class DocumentDownloadService extends ServiceImp implements ConnectedServ
    * Calls LifecycleHelper#stop for the Azure connection.
    */
   @Override
-  public void stop()
-  {
+  public void stop() {
     super.stop();
     LifecycleHelper.stop(connection);
   }
@@ -154,8 +151,7 @@ public class DocumentDownloadService extends ServiceImp implements ConnectedServ
    * Calls LifecycleHelper#close for the Azure connection.
    */
   @Override
-  protected void closeService()
-  {
+  protected void closeService() {
     LifecycleHelper.close(connection);
   }
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentDownloadService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentDownloadService.java
@@ -154,4 +154,5 @@ public class DocumentDownloadService extends ServiceImp implements ConnectedServ
   protected void closeService() {
     LifecycleHelper.close(connection);
   }
+
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentTransformService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentTransformService.java
@@ -1,5 +1,9 @@
 package com.adaptris.interlok.azure.onedrive;
 
+import java.util.LinkedList;
+
+import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -11,22 +15,23 @@ import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairList;
 import com.microsoft.graph.options.QueryOption;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
-import java.util.LinkedList;
-
 /**
- * Retrieve the contents of an item in a specific format. Not all files
- * can be converted into all formats.
+ * Retrieve the contents of an item in a specific format. Not all files can be converted into all formats.
  *
  * Supported formats and their original document type:
  *
- * glb  Converts the item into GLB format from:   cool, fbx, obj, ply, stl, 3mf
- * html Converts the item into HTML format from:  eml, md, msg
- * jpg  Converts the item into JPG format from:   3g2, 3gp, 3gp2, 3gpp, 3mf, ai, arw, asf, avi, bas, bash, bat, bmp, c, cbl, cmd, cool, cpp, cr2, crw, cs, css, csv, cur, dcm, dcm30, dic, dicm, dicom, dng, doc, docx, dwg, eml, epi, eps, epsf, epsi, epub, erf, fbx, fppx, gif, glb, h, hcp, heic, heif, htm, html, ico, icon, java, jfif, jpeg, jpg, js, json, key, log, m2ts, m4a, m4v, markdown, md, mef, mov, movie, mp3, mp4, mp4v, mrw, msg, mts, nef, nrw, numbers, obj, odp, odt, ogg, orf, pages, pano, pdf, pef, php, pict, pl, ply, png, pot, potm, potx, pps, ppsx, ppsxm, ppt, pptm, pptx, ps, ps1, psb, psd, py, raw, rb, rtf, rw1, rw2, sh, sketch, sql, sr2, stl, tif, tiff, ts, txt, vb, webm, wma, wmv, xaml, xbm, xcf, xd, xml, xpm, yaml, yml
- * pdf  Converts the item into PDF format from:   doc, docx, epub, eml, htm, html, md, msg, odp, ods, odt, pps, ppsx, ppt, pptx, rtf, tif, tiff, xls, xlsm, xlsx
+ * glb Converts the item into GLB format from: cool, fbx, obj, ply, stl, 3mf html Converts the item into HTML format from: eml, md, msg jpg
+ * Converts the item into JPG format from: 3g2, 3gp, 3gp2, 3gpp, 3mf, ai, arw, asf, avi, bas, bash, bat, bmp, c, cbl, cmd, cool, cpp, cr2,
+ * crw, cs, css, csv, cur, dcm, dcm30, dic, dicm, dicom, dng, doc, docx, dwg, eml, epi, eps, epsf, epsi, epub, erf, fbx, fppx, gif, glb, h,
+ * hcp, heic, heif, htm, html, ico, icon, java, jfif, jpeg, jpg, js, json, key, log, m2ts, m4a, m4v, markdown, md, mef, mov, movie, mp3,
+ * mp4, mp4v, mrw, msg, mts, nef, nrw, numbers, obj, odp, odt, ogg, orf, pages, pano, pdf, pef, php, pict, pl, ply, png, pot, potm, potx,
+ * pps, ppsx, ppsxm, ppt, pptm, pptx, ps, ps1, psb, psd, py, raw, rb, rtf, rw1, rw2, sh, sketch, sql, sr2, stl, tif, tiff, ts, txt, vb,
+ * webm, wma, wmv, xaml, xbm, xcf, xd, xml, xpm, yaml, yml pdf Converts the item into PDF format from: doc, docx, epub, eml, htm, html, md,
+ * msg, odp, ods, odt, pps, ppsx, ppt, pptx, rtf, tif, tiff, xls, xlsm, xlsx
  *
  * @config azure-one-drive-document-transform-service
  */
@@ -34,8 +39,7 @@ import java.util.LinkedList;
 @AdapterComponent
 @ComponentProfile(summary = "Retrieve the contents of an item in a specific format. Not all files can be converted into all formats.", tag = "file,o365,microsoft,office,365,one drive,transform")
 @DisplayOrder(order = { "username", "filename" })
-public class DocumentTransformService extends DocumentDownloadService
-{
+public class DocumentTransformService extends DocumentDownloadService {
   /**
    * The format of the file to be downloaded.
    */
@@ -54,19 +58,18 @@ public class DocumentTransformService extends DocumentDownloadService
   /**
    * Retrieve the contents of an item in a specific format.
    *
-   * @param adaptrisMessage the <code>AdaptrisMessage</code> to process
-   * @throws ServiceException wrapping any underlying <code>Exception</code>s
+   * @param adaptrisMessage
+   *          the <code>AdaptrisMessage</code> to process
+   * @throws ServiceException
+   *           wrapping any underlying <code>Exception</code>s
    */
   @Override
-  public void doService(AdaptrisMessage adaptrisMessage) throws ServiceException
-  {
+  public void doService(AdaptrisMessage adaptrisMessage) throws ServiceException {
     requestOptions = new LinkedList<>();
     requestOptions.add(new QueryOption("format", format));
 
-    if (additionalRequestOptions != null)
-    {
-      for (KeyValuePair option : additionalRequestOptions)
-      {
+    if (additionalRequestOptions != null) {
+      for (KeyValuePair option : additionalRequestOptions) {
         requestOptions.add(new QueryOption(option.getKey(), option.getValue()));
       }
     }
@@ -74,11 +77,7 @@ public class DocumentTransformService extends DocumentDownloadService
     super.doService(adaptrisMessage);
   }
 
-  public enum Format
-  {
-    GLB,
-    HTML,
-    JPG,
-    PDF;
+  public enum Format {
+    GLB, HTML, JPG, PDF;
   }
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentTransformService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentTransformService.java
@@ -80,4 +80,5 @@ public class DocumentTransformService extends DocumentDownloadService {
   public enum Format {
     GLB, HTML, JPG, PDF;
   }
+
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentUploadService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentUploadService.java
@@ -149,4 +149,5 @@ public class DocumentUploadService extends ServiceImp implements ConnectedServic
   protected void closeService() {
     LifecycleHelper.close(connection);
   }
+
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentUploadService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentUploadService.java
@@ -1,5 +1,8 @@
 package com.adaptris.interlok.azure.onedrive;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -16,11 +19,9 @@ import com.adaptris.core.StandaloneProducer;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.azure.GraphAPIConnection;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 /**
  * Upload the contents of a message to a file in OneDrive.
@@ -29,130 +30,123 @@ import javax.validation.constraints.NotNull;
  */
 @XStreamAlias("azure-one-drive-document-upload-service")
 @AdapterComponent
-@ComponentProfile(summary = "Upload the contents of a message to a file in OneDrive.", tag = "file,o365,microsoft,office,365,one drive,upload", recommended = { GraphAPIConnection.class })
+@ComponentProfile(summary = "Upload the contents of a message to a file in OneDrive.", tag = "file,o365,microsoft,office,365,one drive,upload", recommended = {
+    GraphAPIConnection.class })
 @DisplayOrder(order = { "connection", "username", "filename" })
-public class DocumentUploadService extends ServiceImp implements ConnectedService
-{
-    /**
-     * Connection to Azure OneDrive.
-     */
-    @Getter
-    @Setter
-    @NotNull
-    @InputFieldHint(ofType = "com.adaptris.interlok.azure.AzureConnection")
-    private AdaptrisConnection connection;
+public class DocumentUploadService extends ServiceImp implements ConnectedService {
+  /**
+   * Connection to Azure OneDrive.
+   */
+  @Getter
+  @Setter
+  @NotNull
+  @InputFieldHint(ofType = "com.adaptris.interlok.azure.AzureConnection")
+  private AdaptrisConnection connection;
 
-    /**
-     * The username for which One Drive will be polled.
-     */
-    @Getter
-    @Setter
-    @NotBlank
-    @InputFieldHint(expression = true)
-    private String username;
+  /**
+   * The username for which One Drive will be polled.
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @InputFieldHint(expression = true)
+  private String username;
 
-    /**
-     * The name and path of the file to be uploaded.
-     */
-    @Getter
-    @Setter
-    @NotBlank
-    @InputFieldHint(expression = true, friendly = "The name and path of the file to be uploaded")
-    private String filename;
+  /**
+   * The name and path of the file to be uploaded.
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @InputFieldHint(expression = true, friendly = "The name and path of the file to be uploaded")
+  private String filename;
 
-    /**
-     * Whether to overwrite an existing file of the same name. (Default is true!)
-     */
-    @Getter
-    @Setter
-    @AdvancedConfig
-    @InputFieldDefault("true")
-    private Boolean overwrite;
+  /**
+   * Whether to overwrite an existing file of the same name. (Default is true!)
+   */
+  @Getter
+  @Setter
+  @AdvancedConfig
+  @InputFieldDefault("true")
+  private Boolean overwrite;
 
-    /**
-     * <p>
-     * Apply the service to the message.
-     * </p>
-     *
-     * @param adaptrisMessage the <code>AdaptrisMessage</code> to process
-     * @throws ServiceException wrapping any underlying <code>Exception</code>s
-     */
-    @Override
-    public void doService(AdaptrisMessage adaptrisMessage) throws ServiceException
-    {
-        OneDriveProducer producer = new OneDriveProducer();
-        StandaloneProducer standaloneProducer = new StandaloneProducer(connection, producer);
+  /**
+   * <p>
+   * Apply the service to the message.
+   * </p>
+   *
+   * @param adaptrisMessage
+   *          the <code>AdaptrisMessage</code> to process
+   * @throws ServiceException
+   *           wrapping any underlying <code>Exception</code>s
+   */
+  @Override
+  public void doService(AdaptrisMessage adaptrisMessage) throws ServiceException {
+    OneDriveProducer producer = new OneDriveProducer();
+    StandaloneProducer standaloneProducer = new StandaloneProducer(connection, producer);
 
-        try
-        {
-            producer.registerConnection(connection);
-            producer.setUsername(adaptrisMessage.resolve(username));
-            producer.setFilename(adaptrisMessage.resolve(filename));
-            producer.setOverwrite(overwrite);
+    try {
+      producer.registerConnection(connection);
+      producer.setUsername(adaptrisMessage.resolve(username));
+      producer.setFilename(adaptrisMessage.resolve(filename));
+      producer.setOverwrite(overwrite);
 
-            LifecycleHelper.initAndStart(standaloneProducer, false);
+      LifecycleHelper.initAndStart(standaloneProducer, false);
 
-            standaloneProducer.doService(adaptrisMessage);
-        }
-        catch (Exception e)
-        {
-            log.error("Could not upload file", e);
-            throw new ServiceException(e);
-        }
-        finally
-        {
-            LifecycleHelper.stopAndClose(standaloneProducer, false);
-        }
+      standaloneProducer.doService(adaptrisMessage);
+    } catch (Exception e) {
+      log.error("Could not upload file", e);
+      throw new ServiceException(e);
+    } finally {
+      LifecycleHelper.stopAndClose(standaloneProducer, false);
     }
+  }
 
-    /**
-     * Calls LifecycleHelper#prepare for the Azure connection.
-     *
-     * @throws CoreException If teh connection could not be prepared.
-     */
-    @Override
-    public void prepare() throws CoreException
-    {
-        LifecycleHelper.prepare(connection);
-    }
+  /**
+   * Calls LifecycleHelper#prepare for the Azure connection.
+   *
+   * @throws CoreException
+   *           If teh connection could not be prepared.
+   */
+  @Override
+  public void prepare() throws CoreException {
+    LifecycleHelper.prepare(connection);
+  }
 
-    /**
-     * Calls LifecycleHelper#init for the Azure connection.
-     */
-    @Override
-    protected void initService() throws CoreException
-    {
-        LifecycleHelper.init(connection);
-    }
+  /**
+   * Calls LifecycleHelper#init for the Azure connection.
+   */
+  @Override
+  protected void initService() throws CoreException {
+    LifecycleHelper.init(connection);
+  }
 
-    /**
-     * Calls LifecycleHelper#start for the Azure connection.
-     *
-     * @throws CoreException If teh connection could not be prepared.
-     */
-    @Override
-    public void start() throws CoreException
-    {
-        super.start();
-        LifecycleHelper.start(connection);
-    }
+  /**
+   * Calls LifecycleHelper#start for the Azure connection.
+   *
+   * @throws CoreException
+   *           If teh connection could not be prepared.
+   */
+  @Override
+  public void start() throws CoreException {
+    super.start();
+    LifecycleHelper.start(connection);
+  }
 
-    /**
-     * Calls LifecycleHelper#stop for the Azure connection.
-     */
-    @Override
-    public void stop()
-    {
-        super.stop();
-        LifecycleHelper.stop(connection);
-    }
+  /**
+   * Calls LifecycleHelper#stop for the Azure connection.
+   */
+  @Override
+  public void stop() {
+    super.stop();
+    LifecycleHelper.stop(connection);
+  }
 
-    /**
-     * Calls LifecycleHelper#close for the Azure connection.
-     */
-    @Override
-    protected void closeService()
-    {
-        LifecycleHelper.close(connection);
-    }
+  /**
+   * Calls LifecycleHelper#close for the Azure connection.
+   */
+  @Override
+  protected void closeService() {
+    LifecycleHelper.close(connection);
+  }
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumer.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumer.java
@@ -47,6 +47,7 @@ import lombok.Setter;
 @ComponentProfile(summary = "Pickup files from a Microsoft Office 365 One Drive account using the Microsoft Graph API", tag = "consumer,file,o365,microsoft,office,365,one drive")
 @DisplayOrder(order = { "username" })
 public class OneDriveConsumer extends AdaptrisPollingConsumer {
+
   /**
    * The username for which One Drive will be polled.
    */
@@ -112,4 +113,5 @@ public class OneDriveConsumer extends AdaptrisPollingConsumer {
   protected String newThreadName() {
     return DestinationHelper.threadName(retrieveAdaptrisMessageListener(), null);
   }
+
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumer.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumer.java
@@ -12,9 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package com.adaptris.interlok.azure.onedrive;
+
+import java.io.InputStream;
+import java.util.List;
+
+import javax.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
@@ -23,23 +28,17 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisPollingConsumer;
 import com.adaptris.core.util.DestinationHelper;
 import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.microsoft.graph.models.extensions.Drive;
-import com.microsoft.graph.models.extensions.DriveItem;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionPage;
+import com.microsoft.graph.models.Drive;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.requests.DriveItemCollectionPage;
+import com.microsoft.graph.requests.GraphServiceClient;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.io.IOUtils;
-
-import javax.validation.constraints.NotBlank;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
 
 /**
- * Implementation of a file consumer that can retrieve files from
- * Microsoft One Drive, using their Graph API and OAuth2.
+ * Implementation of a file consumer that can retrieve files from Microsoft One Drive, using their Graph API and OAuth2.
  *
  * @config azure-one-drive-consumer
  */
@@ -47,8 +46,7 @@ import java.util.List;
 @AdapterComponent
 @ComponentProfile(summary = "Pickup files from a Microsoft Office 365 One Drive account using the Microsoft Graph API", tag = "consumer,file,o365,microsoft,office,365,one drive")
 @DisplayOrder(order = { "username" })
-public class OneDriveConsumer extends AdaptrisPollingConsumer
-{
+public class OneDriveConsumer extends AdaptrisPollingConsumer {
   /**
    * The username for which One Drive will be polled.
    */
@@ -61,8 +59,7 @@ public class OneDriveConsumer extends AdaptrisPollingConsumer
    * {@inheritDoc}.
    */
   @Override
-  protected void prepareConsumer()
-  {
+  protected void prepareConsumer() {
     /* do nothing */
   }
 
@@ -72,34 +69,26 @@ public class OneDriveConsumer extends AdaptrisPollingConsumer
    * @return The number of files found.
    */
   @Override
-  protected int processMessages()
-  {
-    log.debug("Polling for files in One Drive as user " + username);
+  protected int processMessages() {
+    log.debug("Polling for files in One Drive as user {}", username);
 
     int count = 0;
-    try
-    {
+    try {
       GraphAPIConnection connection = retrieveConnection(GraphAPIConnection.class);
-      IGraphServiceClient graphClient = connection.getClientConnection();
+      GraphServiceClient<?> graphClient = connection.getClientConnection();
 
       Drive oneDrive = graphClient.users(username).drive().buildRequest().get();
       /*
-       * TODO If paths work in the conventional sense, then it might be
-       *  useful to allow the end user to choose a path
+       * TODO If paths work in the conventional sense, then it might be useful to allow the end user to choose a path
        */
-      IDriveItemCollectionPage children = graphClient.users(username).drives(oneDrive.id).root().children().buildRequest().get();
+      DriveItemCollectionPage children = graphClient.users(username).drives(oneDrive.id).root().children().buildRequest().get();
 
       List<DriveItem> currentPage = children.getCurrentPage();
       log.debug("One Drive {} for user {} has {} items", oneDrive.name, username, currentPage.size());
-      for (DriveItem driveItem : currentPage)
-      {
-        AdaptrisMessage adaptrisMessage = getMessageFactory().newMessage();
-        try (InputStream remoteStream = graphClient.users(username).drives(oneDrive.id).items(driveItem.id).content().buildRequest().get())
-        {
-          try (OutputStream outputStream = adaptrisMessage.getOutputStream())
-          {
-            IOUtils.copy(remoteStream, outputStream);
-          }
+      for (DriveItem driveItem : currentPage) {
+        AdaptrisMessage adaptrisMessage;
+        try (InputStream remoteStream = graphClient.users(username).drives(oneDrive.id).items(driveItem.id).content().buildRequest().get()) {
+          adaptrisMessage = decode(remoteStream.readAllBytes());
         }
 
         adaptrisMessage.addMetadata("filename", driveItem.name);
@@ -109,9 +98,7 @@ public class OneDriveConsumer extends AdaptrisPollingConsumer
         count++;
       }
 
-    }
-    catch (Throwable e)
-    {
+    } catch (Throwable e) {
       log.error("Exception processing One Drive file", e);
     }
 
@@ -122,8 +109,7 @@ public class OneDriveConsumer extends AdaptrisPollingConsumer
    * {@inheritDoc}.
    */
   @Override
-  protected String newThreadName()
-  {
+  protected String newThreadName() {
     return DestinationHelper.threadName(retrieveAdaptrisMessageListener(), null);
   }
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveProducer.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveProducer.java
@@ -163,4 +163,5 @@ public class OneDriveProducer extends ProduceOnlyProducerImp {
   private boolean overwrite() {
     return BooleanUtils.toBooleanDefaultIfNull(overwrite, true);
   }
+
 }

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveProducer.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveProducer.java
@@ -1,5 +1,12 @@
 package com.adaptris.interlok.azure.onedrive;
 
+import java.util.Optional;
+
+import javax.validation.constraints.NotBlank;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.BooleanUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -10,26 +17,21 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.ProduceOnlyProducerImp;
 import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.microsoft.graph.concurrency.ChunkedUploadProvider;
-import com.microsoft.graph.concurrency.IProgressCallback;
-import com.microsoft.graph.core.ClientException;
-import com.microsoft.graph.models.extensions.DriveItem;
-import com.microsoft.graph.models.extensions.DriveItemUploadableProperties;
-import com.microsoft.graph.models.extensions.File;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.models.extensions.UploadSession;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionPage;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.models.DriveItemCreateUploadSessionParameterSet;
+import com.microsoft.graph.models.File;
+import com.microsoft.graph.models.UploadSession;
+import com.microsoft.graph.requests.DriveItemCollectionPage;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.tasks.IProgressCallback;
+import com.microsoft.graph.tasks.LargeFileUploadTask;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.BooleanUtils;
-
-import javax.validation.constraints.NotBlank;
 
 /**
- * Implementation of a file producer that can place files into a
- * Microsoft One Drive account, using their Graph API and OAuth2.
+ * Implementation of a file producer that can place files into a Microsoft One Drive account, using their Graph API and OAuth2.
  *
  * @config azure-one-drive-producer
  */
@@ -37,8 +39,7 @@ import javax.validation.constraints.NotBlank;
 @AdapterComponent
 @ComponentProfile(summary = "Place files into a Microsoft Office 365 One Drive account using the Microsoft Graph API", tag = "producer,file,o365,microsoft,office,365,one drive")
 @DisplayOrder(order = { "username" })
-public class OneDriveProducer extends ProduceOnlyProducerImp
-{
+public class OneDriveProducer extends ProduceOnlyProducerImp {
   /**
    * The username for which One Drive will be polled.
    */
@@ -70,30 +71,29 @@ public class OneDriveProducer extends ProduceOnlyProducerImp
    * {@inheritDoc}.
    */
   @Override
-  public void prepare()
-  {
-    /* do nothing */
+  public void prepare() {
   }
 
   /**
    * Push the Adaptris message, as a file, to the given One Drive.
    *
-   * @param adaptrisMessage The message to upload.
-   * @param endpoint        Ignored.
-   * @throws ProduceException If there was a uploading the file.
+   * @param adaptrisMessage
+   *          The message to upload.
+   * @param endpoint
+   *          Ignored.
+   * @throws ProduceException
+   *           If there was a uploading the file.
    */
   @Override
-  protected void doProduce(AdaptrisMessage adaptrisMessage, String endpoint) throws ProduceException
-  {
+  protected void doProduce(AdaptrisMessage adaptrisMessage, String endpoint) throws ProduceException {
     String user = adaptrisMessage.resolve(username);
     String file = adaptrisMessage.resolve(filename);
 
     log.debug("Pushing file {} to One Drive as user {}", file, user);
 
-    try
-    {
+    try {
       GraphAPIConnection connection = retrieveConnection(GraphAPIConnection.class);
-      IGraphServiceClient graphClient = connection.getClientConnection();
+      GraphServiceClient<?> graphClient = connection.getClientConnection();
 
       DriveItem newItem = new DriveItem();
       newItem.file = new File();
@@ -101,81 +101,66 @@ public class OneDriveProducer extends ProduceOnlyProducerImp
       newItem.size = adaptrisMessage.getSize();
 
       boolean isNew = true;
-      if (overwrite())
-      {
+      if (overwrite()) {
         /*
-         * By default One Drive doesn't allow files to be overwritten
-         * unless the DriveItem.id matches, so quickly get it
+         * By default One Drive doesn't allow files to be overwritten unless the DriveItem.id matches, so quickly get it
          */
-        IDriveItemCollectionPage children = graphClient.users(user).drive().root().children().buildRequest().get();
-        for (DriveItem driveItem : children.getCurrentPage())
-        {
-          if (driveItem.name.equals(newItem.name))
-          {
-            newItem = driveItem;
-            isNew = false;
-            break;
-          }
+        if (getDriveItem(graphClient, user, file).isPresent()) {
+          newItem = getDriveItem(graphClient, user, file).get();
+          isNew = false;
         }
+
       }
 
-      if (isNew)
-      {
-        // create what could be thought of as a directory entry
+      if (isNew) {
+        // Create what could be thought of as a directory entry
         newItem = graphClient.users(user).drive().items().buildRequest().post(newItem);
       }
 
-      // upload the file data
-      if (adaptrisMessage.getSize() < 4 * FileUtils.ONE_MB)
-      {
+      // Upload the file data
+      if (adaptrisMessage.getSize() < 4 * FileUtils.ONE_MB) {
         graphClient.users(user).drive().items(newItem.id).content().buildRequest().put(adaptrisMessage.getPayload());
-      }
-      else
-      {
+      } else {
         String name = newItem.name;
-        UploadSession uploadSession = graphClient.users(user).drive().items(newItem.id).createUploadSession(new DriveItemUploadableProperties()).buildRequest().post();
-        ChunkedUploadProvider<DriveItem> chunkedUploadProvider = new ChunkedUploadProvider<>(uploadSession, graphClient, adaptrisMessage.getInputStream(), adaptrisMessage.getSize(), DriveItem.class);
-        chunkedUploadProvider.upload(new IProgressCallback()
-        {
-          @Override
-          public void success(Object o)
-          {
-            log.debug("Successfully uploaded {}", name);
-          }
+        UploadSession uploadSession = graphClient.users(user).drive().items(newItem.id)
+            .createUploadSession(new DriveItemCreateUploadSessionParameterSet()).buildRequest().post();
 
-          @Override
-          public void failure(ClientException ex)
-          {
-            log.error("Could not process attachment {} for message {} : {}", name, adaptrisMessage.getUniqueId(), ex);
-          }
+        LargeFileUploadTask<DriveItem> largeFileUploadTask = new LargeFileUploadTask<>(uploadSession, graphClient,
+            adaptrisMessage.getInputStream(), adaptrisMessage.getSize(), DriveItem.class);
 
+        largeFileUploadTask.upload(0, null, new IProgressCallback() {
           @Override
-          public void progress(long current, long max)
-          {
+          public void progress(long current, long max) {
             log.debug("Uploading file {} progress is {} / {}", name, current, max);
           }
         });
 
       }
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       log.error("Exception processing One Drive file", e);
       throw new ProduceException(e);
     }
+  }
+
+  private Optional<DriveItem> getDriveItem(GraphServiceClient<?> graphClient, String user, String name) {
+    DriveItemCollectionPage children = graphClient.users(user).drive().root().children().buildRequest().get();
+    for (DriveItem driveItem : children.getCurrentPage()) {
+      if (driveItem.name.equals(name)) {
+        return Optional.of(driveItem);
+      }
+    }
+    return Optional.empty();
   }
 
   /**
    * {@inheritDoc}.
    */
   @Override
-  public String endpoint(AdaptrisMessage adaptrisMessage)
-  {
+  public String endpoint(AdaptrisMessage adaptrisMessage) {
     return adaptrisMessage.resolve(username);
   }
 
-  private boolean overwrite()
-  {
+  private boolean overwrite() {
     return BooleanUtils.toBooleanDefaultIfNull(overwrite, true);
   }
 }

--- a/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/DocumentUpDownServiceTest.java
+++ b/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/DocumentUpDownServiceTest.java
@@ -1,31 +1,13 @@
 package com.adaptris.interlok.azure.onedrive;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceList;
-import com.adaptris.interlok.azure.AzureConnection;
-import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
-import com.adaptris.util.KeyValuePair;
-import com.adaptris.util.KeyValuePairList;
-import com.microsoft.graph.models.extensions.Drive;
-import com.microsoft.graph.models.extensions.DriveItem;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.options.Option;
-import com.microsoft.graph.requests.extensions.DriveRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionPage;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveItemContentStreamRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemContentStreamRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveItemRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveRequestBuilder;
-import com.microsoft.graph.requests.extensions.IUserRequestBuilder;
-import org.apache.commons.io.IOUtils;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
@@ -34,277 +16,297 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceList;
+import com.adaptris.interlok.azure.AzureConnection;
+import com.adaptris.interlok.azure.GraphAPIConnection;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairList;
+import com.microsoft.graph.models.Drive;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.options.Option;
+import com.microsoft.graph.requests.DriveItemCollectionPage;
+import com.microsoft.graph.requests.DriveItemCollectionRequest;
+import com.microsoft.graph.requests.DriveItemCollectionRequestBuilder;
+import com.microsoft.graph.requests.DriveItemContentStreamRequest;
+import com.microsoft.graph.requests.DriveItemContentStreamRequestBuilder;
+import com.microsoft.graph.requests.DriveItemRequest;
+import com.microsoft.graph.requests.DriveItemRequestBuilder;
+import com.microsoft.graph.requests.DriveRequest;
+import com.microsoft.graph.requests.DriveRequestBuilder;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.UserRequestBuilder;
 
 public class DocumentUpDownServiceTest extends ExampleServiceCase
 {
-    private static final String APPLICATION_ID = "47ea49b0-670a-47c1-9303-0b45ffb766ec";
-    private static final String TENANT_ID = "cbf4a38d-3117-48cd-b54b-861480ee93cd";
-    private static final String CLIENT_SECRET = "NGMyYjY0MTEtOTU0Ny00NTg0LWE3MzQtODg2ZDAzZGVmZmY1Cg==";
+  private static final String APPLICATION_ID = "47ea49b0-670a-47c1-9303-0b45ffb766ec";
+  private static final String TENANT_ID = "cbf4a38d-3117-48cd-b54b-861480ee93cd";
+  private static final String CLIENT_SECRET = "NGMyYjY0MTEtOTU0Ny00NTg0LWE3MzQtODg2ZDAzZGVmZmY1Cg==";
 
-    private static final String ORIGINAL = "beer.md";
-    private static final String CONVERT = "beer.html";
+  private static final String ORIGINAL = "beer.md";
+  private static final String CONVERT = "beer.html";
 
-    private AzureConnection connection;
+  private AzureConnection connection;
 
-    private String username = "user@example.com";
-    private String data;
-    private String html;
+  private String username = "user@example.com";
+  private String data;
+  private String html;
 
-    private boolean liveTests = false;
+  private boolean liveTests = false;
 
-    @Before
-    public void setUp() throws Exception
+  @Before
+  public void setUp() throws Exception
+  {
+    Properties properties = new Properties();
+    try
     {
-        Properties properties = new Properties();
-        try
-        {
-            properties.load(new FileInputStream(this.getClass().getResource("onedrive.properties").getFile()));
-            liveTests = true;
-        }
-        catch (Exception e)
-        {
-            // do nothing
-        }
-
-        connection = new GraphAPIConnection();
-        connection.setApplicationId(properties.getProperty("APPLICATION_ID", APPLICATION_ID));
-        connection.setTenantId(properties.getProperty("TENANT_ID", TENANT_ID));
-        connection.setClientSecret(properties.getProperty("CLIENT_SECRET", CLIENT_SECRET));
-
-        if (properties.containsKey("USERNAME"))
-        {
-            username = properties.getProperty("USERNAME");
-        }
-
-        data = IOUtils.toString(new FileInputStream(this.getClass().getResource(ORIGINAL).getFile()), Charset.defaultCharset());
-        // The MS Azure markdown to HTML transform doesn't include <html> tags
-        html = IOUtils.toString(new FileInputStream(this.getClass().getResource(CONVERT).getFile()), Charset.defaultCharset());
+      properties.load(new FileInputStream(this.getClass().getResource("onedrive.properties").getFile()));
+      liveTests = true;
+    }
+    catch (Exception e)
+    {
+      // do nothing
     }
 
-    /**
-     * Run through the service tests: upload a CSV file, download it, download & transform it.
-     *
-     * @throws Exception If something goes bang.
-     */
-    @Test
-    public void liveTests() throws Exception
+    connection = new GraphAPIConnection();
+    connection.setApplicationId(properties.getProperty("APPLICATION_ID", APPLICATION_ID));
+    connection.setTenantId(properties.getProperty("TENANT_ID", TENANT_ID));
+    connection.setClientSecret(properties.getProperty("CLIENT_SECRET", CLIENT_SECRET));
+
+    if (properties.containsKey("USERNAME"))
     {
-        Assume.assumeTrue(liveTests);
-
-        AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(data);
-
-        DocumentUploadService upload = documentUploadService();
-        DocumentDownloadService download = documentDownloadService();
-        DocumentTransformService transform = documentTransformService();
-
-        // whether or not this test has ever run before, this should result in the test file being available
-        upload.doService(message);
-
-        // get a new empty message so we can confirm we've downloaded the correct data
-        message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-        download.doService(message);
-
-        assertEquals(data, message.getContent());
-
-        transform.setFormat(DocumentTransformService.Format.PDF);
-        transform.doService(message);
-        assertTrue(message.getContent().startsWith("%PDF"));
-
-        transform.setFormat(DocumentTransformService.Format.HTML);
-        transform.doService(message);
-        assertEquals(html, message.getContent());
-
-        transform.setFormat(DocumentTransformService.Format.JPG);
-        KeyValuePairList additionalOptions = new KeyValuePairList();
-        additionalOptions.addKeyValuePair(new KeyValuePair("width", "1000"));
-        additionalOptions.addKeyValuePair(new KeyValuePair("height", "1000"));
-        transform.setAdditionalRequestOptions(additionalOptions);
-        transform.doService(message);
-//        assertTrue(message.getContent().startsWith("?"));
-// Sometimes I had JPEG, sometimes PNG data returned; if no exception is thrown, I'd say we're good
+      username = properties.getProperty("USERNAME");
     }
 
-    @Test
-    public void mockUploadTest() throws Exception
-    {
-        Assume.assumeFalse(liveTests);
+    data = IOUtils.toString(new FileInputStream(this.getClass().getResource(ORIGINAL).getFile()), Charset.defaultCharset());
+    // The MS Azure markdown to HTML transform doesn't include <html> tags
+    html = IOUtils.toString(new FileInputStream(this.getClass().getResource(CONVERT).getFile()), Charset.defaultCharset());
+  }
 
-        DocumentUploadService upload = documentUploadService();
+  /**
+   * Run through the service tests: upload a CSV file, download it, download & transform it.
+   *
+   * @throws Exception If something goes bang.
+   */
+  @Test
+  public void liveTests() throws Exception
+  {
+    Assume.assumeTrue(liveTests);
 
-        connection = mock(GraphAPIConnection.class);
-        upload.setConnection(connection);
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(data);
 
-        when(connection.retrieveConnection(any())).thenReturn(connection);
-        IGraphServiceClient client = mock(IGraphServiceClient.class);
-        when(connection.getClientConnection()).thenReturn(client);
+    DocumentUploadService upload = documentUploadService();
+    DocumentDownloadService download = documentDownloadService();
+    DocumentTransformService transform = documentTransformService();
 
-        IUserRequestBuilder userRequestBuilder = mock(IUserRequestBuilder.class);
-        when(client.users(username)).thenReturn(userRequestBuilder);
-        IDriveRequestBuilder driveRequestBuilder = mock(IDriveRequestBuilder.class);
-        when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
-        DriveRequest driveRequest = mock(DriveRequest.class);
-        when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
+    // whether or not this test has ever run before, this should result in the test file being available
+    upload.doService(message);
 
-        IDriveItemRequestBuilder driveItemRequestBuilder = mock(IDriveItemRequestBuilder.class);
-        when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
-        IDriveItemCollectionRequestBuilder childrenRequest = mock(IDriveItemCollectionRequestBuilder.class);
-        when(driveItemRequestBuilder.children()).thenReturn(childrenRequest);
-        IDriveItemCollectionRequest children = mock(IDriveItemCollectionRequest.class);
-        when(childrenRequest.buildRequest()).thenReturn(children);
-        IDriveItemCollectionPage migraine = mock(IDriveItemCollectionPage.class);
-        when(children.get()).thenReturn(migraine);
+    // get a new empty message so we can confirm we've downloaded the correct data
+    message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    download.doService(message);
 
-        DriveItem fileReference = new DriveItem();
-        fileReference.id = "73271d08680510a91aec95295ed03b90";
-        fileReference.name = ORIGINAL;
-        fileReference.size = (long)data.length();
-        when(migraine.getCurrentPage()).thenReturn(Arrays.asList(fileReference));
+    assertEquals(data, message.getContent());
 
-        when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
-        IDriveItemContentStreamRequestBuilder streamRequestBuilder = mock(IDriveItemContentStreamRequestBuilder.class);
-        when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
-        IDriveItemContentStreamRequest streamRequest = mock(IDriveItemContentStreamRequest.class);
-        when(streamRequestBuilder.buildRequest()).thenReturn(streamRequest);
+    transform.setFormat(DocumentTransformService.Format.PDF);
+    transform.doService(message);
+    assertTrue(message.getContent().startsWith("%PDF"));
 
-        upload.doService(AdaptrisMessageFactory.getDefaultInstance().newMessage(data));
+    transform.setFormat(DocumentTransformService.Format.HTML);
+    transform.doService(message);
+    assertEquals(html, message.getContent());
 
-        verify(streamRequest, times(1)).put(data.getBytes(Charset.defaultCharset()));
-    }
+    transform.setFormat(DocumentTransformService.Format.JPG);
+    KeyValuePairList additionalOptions = new KeyValuePairList();
+    additionalOptions.addKeyValuePair(new KeyValuePair("width", "1000"));
+    additionalOptions.addKeyValuePair(new KeyValuePair("height", "1000"));
+    transform.setAdditionalRequestOptions(additionalOptions);
+    transform.doService(message);
+    //        assertTrue(message.getContent().startsWith("?"));
+    // Sometimes I had JPEG, sometimes PNG data returned; if no exception is thrown, I'd say we're good
+  }
 
-    @Test
-    public void mockDownloadTest() throws Exception
-    {
-        Assume.assumeFalse(liveTests);
+  @Test
+  public void mockUploadTest() throws Exception
+  {
+    Assume.assumeFalse(liveTests);
 
-        DocumentDownloadService download = documentDownloadService();
+    DocumentUploadService upload = documentUploadService();
 
-        connection = mock(GraphAPIConnection.class);
-        download.setConnection(connection);
+    connection = mock(GraphAPIConnection.class);
+    upload.setConnection(connection);
 
-        when(connection.retrieveConnection(any())).thenReturn(connection);
-        IGraphServiceClient client = mock(IGraphServiceClient.class);
-        when(connection.getClientConnection()).thenReturn(client);
-        IUserRequestBuilder userRequestBuilder = mock(IUserRequestBuilder.class);
-        when(client.users(username)).thenReturn(userRequestBuilder);
-        IDriveRequestBuilder driveRequestBuilder = mock(IDriveRequestBuilder.class);
-        when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
-        DriveRequest driveRequest = mock(DriveRequest.class);
-        when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
-        Drive drive = new Drive();
-        drive.id = "8e7a00f1daf1c2b7015459dd686856c2";
-        when(driveRequest.get()).thenReturn(drive);
-        when(userRequestBuilder.drives(drive.id)).thenReturn(driveRequestBuilder);
-        IDriveItemRequestBuilder driveItemRequestBuilder = mock(IDriveItemRequestBuilder.class);
-        when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
-        when(driveItemRequestBuilder.itemWithPath(ORIGINAL)).thenReturn(driveItemRequestBuilder);
-        IDriveItemRequest driveItemRequest = mock(IDriveItemRequest.class);
-        when(driveItemRequestBuilder.buildRequest()).thenReturn(driveItemRequest);
-        DriveItem fileReference = new DriveItem();
-        fileReference.id = "73271d08680510a91aec95295ed03b90";
-        fileReference.name = ORIGINAL;
-        fileReference.size = (long)data.length();
-        when(driveItemRequest.get()).thenReturn(fileReference);
-        when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
-        IDriveItemContentStreamRequestBuilder streamRequestBuilder = mock(IDriveItemContentStreamRequestBuilder.class);
-        when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
-        IDriveItemContentStreamRequest streamRequest = mock(IDriveItemContentStreamRequest.class);
-        when(streamRequestBuilder.buildRequest((List<Option>)null)).thenReturn(streamRequest);
-        when(streamRequest.get()).thenReturn(new ByteArrayInputStream(data.getBytes(Charset.defaultCharset())));
+    when(connection.retrieveConnection(any())).thenReturn(connection);
+    GraphServiceClient client = mock(GraphServiceClient.class);
+    when(connection.getClientConnection()).thenReturn(client);
 
-        AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-        download.doService(message);
-        assertEquals(data, message.getContent());
-        assertEquals(ORIGINAL, message.getMetadataValue("filename"));
-    }
+    UserRequestBuilder userRequestBuilder = mock(UserRequestBuilder.class);
+    when(client.users(username)).thenReturn(userRequestBuilder);
+    DriveRequestBuilder driveRequestBuilder = mock(DriveRequestBuilder.class);
+    when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
+    DriveRequest driveRequest = mock(DriveRequest.class);
+    when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
 
-    @Test
-    public void mockTransformTest() throws Exception
-    {
-        Assume.assumeFalse(liveTests);
+    DriveItemRequestBuilder driveItemRequestBuilder = mock(DriveItemRequestBuilder.class);
+    when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
+    DriveItemCollectionRequestBuilder childrenRequest = mock(DriveItemCollectionRequestBuilder.class);
+    when(driveItemRequestBuilder.children()).thenReturn(childrenRequest);
+    DriveItemCollectionRequest children = mock(DriveItemCollectionRequest.class);
+    when(childrenRequest.buildRequest()).thenReturn(children);
+    DriveItemCollectionPage migraine = mock(DriveItemCollectionPage.class);
+    when(children.get()).thenReturn(migraine);
 
-        DocumentTransformService transform = documentTransformService();
+    DriveItem fileReference = new DriveItem();
+    fileReference.id = "73271d08680510a91aec95295ed03b90";
+    fileReference.name = ORIGINAL;
+    fileReference.size = Long.valueOf(data.length());
+    when(migraine.getCurrentPage()).thenReturn(Arrays.asList(fileReference));
 
-        connection = mock(GraphAPIConnection.class);
-        transform.setConnection(connection);
+    when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
+    DriveItemContentStreamRequestBuilder streamRequestBuilder = mock(DriveItemContentStreamRequestBuilder.class);
+    when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
+    DriveItemContentStreamRequest streamRequest = mock(DriveItemContentStreamRequest.class);
+    when(streamRequestBuilder.buildRequest()).thenReturn(streamRequest);
 
-        when(connection.retrieveConnection(any())).thenReturn(connection);
-        IGraphServiceClient client = mock(IGraphServiceClient.class);
-        when(connection.getClientConnection()).thenReturn(client);
-        IUserRequestBuilder userRequestBuilder = mock(IUserRequestBuilder.class);
-        when(client.users(username)).thenReturn(userRequestBuilder);
-        IDriveRequestBuilder driveRequestBuilder = mock(IDriveRequestBuilder.class);
-        when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
-        DriveRequest driveRequest = mock(DriveRequest.class);
-        when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
-        Drive drive = new Drive();
-        drive.id = "8e7a00f1daf1c2b7015459dd686856c2";
-        when(driveRequest.get()).thenReturn(drive);
-        when(userRequestBuilder.drives(drive.id)).thenReturn(driveRequestBuilder);
-        IDriveItemRequestBuilder driveItemRequestBuilder = mock(IDriveItemRequestBuilder.class);
-        when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
-        when(driveItemRequestBuilder.itemWithPath(ORIGINAL)).thenReturn(driveItemRequestBuilder);
-        IDriveItemRequest driveItemRequest = mock(IDriveItemRequest.class);
-        when(driveItemRequestBuilder.buildRequest()).thenReturn(driveItemRequest);
-        DriveItem fileReference = new DriveItem();
-        fileReference.id = "73271d08680510a91aec95295ed03b90";
-        fileReference.name = CONVERT;
-        fileReference.size = (long)html.length();
-        when(driveItemRequest.get()).thenReturn(fileReference);
-        when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
-        IDriveItemContentStreamRequestBuilder streamRequestBuilder = mock(IDriveItemContentStreamRequestBuilder.class);
-        when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
-        IDriveItemContentStreamRequest streamRequest = mock(IDriveItemContentStreamRequest.class);
-        when(streamRequestBuilder.buildRequest(any(List.class))).thenReturn(streamRequest);
-        when(streamRequest.get()).thenReturn(new ByteArrayInputStream(html.getBytes(Charset.defaultCharset())));
+    upload.doService(AdaptrisMessageFactory.getDefaultInstance().newMessage(data));
 
-        AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-        transform.doService(message);
-        assertEquals(html, message.getContent());
-        assertEquals(CONVERT, message.getMetadataValue("filename"));
-    }
+    verify(streamRequest, times(1)).put(data.getBytes(Charset.defaultCharset()));
+  }
 
-    @Override
-    protected Object retrieveObjectForSampleConfig()
-    {
-        ServiceList serviceList = new ServiceList();
-        serviceList.add(documentUploadService());
-        serviceList.add(documentDownloadService());
-        serviceList.add(documentTransformService());
-        return serviceList;
-    }
+  @Test
+  public void mockDownloadTest() throws Exception
+  {
+    Assume.assumeFalse(liveTests);
 
-    private DocumentUploadService documentUploadService()
-    {
-        DocumentUploadService service = new DocumentUploadService();
-        service.setConnection(connection);
-        service.setUsername(username);
-        service.setFilename(ORIGINAL);
-        return service;
-    }
+    DocumentDownloadService download = documentDownloadService();
 
-    private DocumentDownloadService documentDownloadService()
-    {
-        DocumentDownloadService service = new DocumentDownloadService();
-        service.setConnection(connection);
-        service.setUsername(username);
-        service.setFilename(ORIGINAL);
-        return service;
-    }
+    connection = mock(GraphAPIConnection.class);
+    download.setConnection(connection);
 
-    private DocumentTransformService documentTransformService()
-    {
-        DocumentTransformService service = new DocumentTransformService();
-        service.setConnection(connection);
-        service.setUsername(username);
-        service.setFilename(ORIGINAL);
-        service.setFormat(DocumentTransformService.Format.GLB);
-        return service;
-    }
+    when(connection.retrieveConnection(any())).thenReturn(connection);
+    GraphServiceClient client = mock(GraphServiceClient.class);
+    when(connection.getClientConnection()).thenReturn(client);
+    UserRequestBuilder userRequestBuilder = mock(UserRequestBuilder.class);
+    when(client.users(username)).thenReturn(userRequestBuilder);
+    DriveRequestBuilder driveRequestBuilder = mock(DriveRequestBuilder.class);
+    when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
+    DriveRequest driveRequest = mock(DriveRequest.class);
+    when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
+    Drive drive = new Drive();
+    drive.id = "8e7a00f1daf1c2b7015459dd686856c2";
+    when(driveRequest.get()).thenReturn(drive);
+    when(userRequestBuilder.drives(drive.id)).thenReturn(driveRequestBuilder);
+    DriveItemRequestBuilder driveItemRequestBuilder = mock(DriveItemRequestBuilder.class);
+    when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
+    when(driveItemRequestBuilder.itemWithPath(ORIGINAL)).thenReturn(driveItemRequestBuilder);
+    DriveItemRequest driveItemRequest = mock(DriveItemRequest.class);
+    when(driveItemRequestBuilder.buildRequest()).thenReturn(driveItemRequest);
+    DriveItem fileReference = new DriveItem();
+    fileReference.id = "73271d08680510a91aec95295ed03b90";
+    fileReference.name = ORIGINAL;
+    fileReference.size = Long.valueOf(data.length());
+    when(driveItemRequest.get()).thenReturn(fileReference);
+    when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
+    DriveItemContentStreamRequestBuilder streamRequestBuilder = mock(DriveItemContentStreamRequestBuilder.class);
+    when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
+    DriveItemContentStreamRequest streamRequest = mock(DriveItemContentStreamRequest.class);
+    when(streamRequestBuilder.buildRequest((List<Option>)null)).thenReturn(streamRequest);
+    when(streamRequest.get()).thenReturn(new ByteArrayInputStream(data.getBytes(Charset.defaultCharset())));
+
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    download.doService(message);
+    assertEquals(data, message.getContent());
+    assertEquals(ORIGINAL, message.getMetadataValue("filename"));
+  }
+
+  @Test
+  public void mockTransformTest() throws Exception
+  {
+    Assume.assumeFalse(liveTests);
+
+    DocumentTransformService transform = documentTransformService();
+
+    connection = mock(GraphAPIConnection.class);
+    transform.setConnection(connection);
+
+    when(connection.retrieveConnection(any())).thenReturn(connection);
+    GraphServiceClient client = mock(GraphServiceClient.class);
+    when(connection.getClientConnection()).thenReturn(client);
+    UserRequestBuilder userRequestBuilder = mock(UserRequestBuilder.class);
+    when(client.users(username)).thenReturn(userRequestBuilder);
+    DriveRequestBuilder driveRequestBuilder = mock(DriveRequestBuilder.class);
+    when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
+    DriveRequest driveRequest = mock(DriveRequest.class);
+    when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
+    Drive drive = new Drive();
+    drive.id = "8e7a00f1daf1c2b7015459dd686856c2";
+    when(driveRequest.get()).thenReturn(drive);
+    when(userRequestBuilder.drives(drive.id)).thenReturn(driveRequestBuilder);
+    DriveItemRequestBuilder driveItemRequestBuilder = mock(DriveItemRequestBuilder.class);
+    when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
+    when(driveItemRequestBuilder.itemWithPath(ORIGINAL)).thenReturn(driveItemRequestBuilder);
+    DriveItemRequest driveItemRequest = mock(DriveItemRequest.class);
+    when(driveItemRequestBuilder.buildRequest()).thenReturn(driveItemRequest);
+    DriveItem fileReference = new DriveItem();
+    fileReference.id = "73271d08680510a91aec95295ed03b90";
+    fileReference.name = CONVERT;
+    fileReference.size = Long.valueOf(html.length());
+    when(driveItemRequest.get()).thenReturn(fileReference);
+    when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
+    DriveItemContentStreamRequestBuilder streamRequestBuilder = mock(DriveItemContentStreamRequestBuilder.class);
+    when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
+    DriveItemContentStreamRequest streamRequest = mock(DriveItemContentStreamRequest.class);
+    when(streamRequestBuilder.buildRequest(isA(List.class))).thenReturn(streamRequest);
+    when(streamRequest.get()).thenReturn(new ByteArrayInputStream(html.getBytes(Charset.defaultCharset())));
+
+    AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    transform.doService(message);
+    assertEquals(html, message.getContent());
+    assertEquals(CONVERT, message.getMetadataValue("filename"));
+  }
+
+  @Override
+  protected Object retrieveObjectForSampleConfig()
+  {
+    ServiceList serviceList = new ServiceList();
+    serviceList.add(documentUploadService());
+    serviceList.add(documentDownloadService());
+    serviceList.add(documentTransformService());
+    return serviceList;
+  }
+
+  private DocumentUploadService documentUploadService()
+  {
+    DocumentUploadService service = new DocumentUploadService();
+    service.setConnection(connection);
+    service.setUsername(username);
+    service.setFilename(ORIGINAL);
+    return service;
+  }
+
+  private DocumentDownloadService documentDownloadService()
+  {
+    DocumentDownloadService service = new DocumentDownloadService();
+    service.setConnection(connection);
+    service.setUsername(username);
+    service.setFilename(ORIGINAL);
+    return service;
+  }
+
+  private DocumentTransformService documentTransformService()
+  {
+    DocumentTransformService service = new DocumentTransformService();
+    service.setConnection(connection);
+    service.setUsername(username);
+    service.setFilename(ORIGINAL);
+    service.setFormat(DocumentTransformService.Format.GLB);
+    return service;
+  }
 }

--- a/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/DocumentUpDownServiceTest.java
+++ b/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/DocumentUpDownServiceTest.java
@@ -44,8 +44,7 @@ import com.microsoft.graph.requests.DriveRequestBuilder;
 import com.microsoft.graph.requests.GraphServiceClient;
 import com.microsoft.graph.requests.UserRequestBuilder;
 
-public class DocumentUpDownServiceTest extends ExampleServiceCase
-{
+public class DocumentUpDownServiceTest extends ExampleServiceCase {
   private static final String APPLICATION_ID = "47ea49b0-670a-47c1-9303-0b45ffb766ec";
   private static final String TENANT_ID = "cbf4a38d-3117-48cd-b54b-861480ee93cd";
   private static final String CLIENT_SECRET = "NGMyYjY0MTEtOTU0Ny00NTg0LWE3MzQtODg2ZDAzZGVmZmY1Cg==";
@@ -62,16 +61,12 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
   private boolean liveTests = false;
 
   @Before
-  public void setUp() throws Exception
-  {
+  public void setUp() throws Exception {
     Properties properties = new Properties();
-    try
-    {
+    try {
       properties.load(new FileInputStream(this.getClass().getResource("onedrive.properties").getFile()));
       liveTests = true;
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       // do nothing
     }
 
@@ -80,8 +75,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
     connection.setTenantId(properties.getProperty("TENANT_ID", TENANT_ID));
     connection.setClientSecret(properties.getProperty("CLIENT_SECRET", CLIENT_SECRET));
 
-    if (properties.containsKey("USERNAME"))
-    {
+    if (properties.containsKey("USERNAME")) {
       username = properties.getProperty("USERNAME");
     }
 
@@ -93,11 +87,11 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
   /**
    * Run through the service tests: upload a CSV file, download it, download & transform it.
    *
-   * @throws Exception If something goes bang.
+   * @throws Exception
+   *           If something goes bang.
    */
   @Test
-  public void liveTests() throws Exception
-  {
+  public void liveTests() throws Exception {
     Assume.assumeTrue(liveTests);
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(data);
@@ -129,13 +123,12 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
     additionalOptions.addKeyValuePair(new KeyValuePair("height", "1000"));
     transform.setAdditionalRequestOptions(additionalOptions);
     transform.doService(message);
-    //        assertTrue(message.getContent().startsWith("?"));
+    // assertTrue(message.getContent().startsWith("?"));
     // Sometimes I had JPEG, sometimes PNG data returned; if no exception is thrown, I'd say we're good
   }
 
   @Test
-  public void mockUploadTest() throws Exception
-  {
+  public void mockUploadTest() throws Exception {
     Assume.assumeFalse(liveTests);
 
     DocumentUploadService upload = documentUploadService();
@@ -181,8 +174,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
   }
 
   @Test
-  public void mockDownloadTest() throws Exception
-  {
+  public void mockDownloadTest() throws Exception {
     Assume.assumeFalse(liveTests);
 
     DocumentDownloadService download = documentDownloadService();
@@ -217,7 +209,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
     DriveItemContentStreamRequestBuilder streamRequestBuilder = mock(DriveItemContentStreamRequestBuilder.class);
     when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
     DriveItemContentStreamRequest streamRequest = mock(DriveItemContentStreamRequest.class);
-    when(streamRequestBuilder.buildRequest((List<Option>)null)).thenReturn(streamRequest);
+    when(streamRequestBuilder.buildRequest((List<Option>) null)).thenReturn(streamRequest);
     when(streamRequest.get()).thenReturn(new ByteArrayInputStream(data.getBytes(Charset.defaultCharset())));
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage();
@@ -227,8 +219,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
   }
 
   @Test
-  public void mockTransformTest() throws Exception
-  {
+  public void mockTransformTest() throws Exception {
     Assume.assumeFalse(liveTests);
 
     DocumentTransformService transform = documentTransformService();
@@ -273,8 +264,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
   }
 
   @Override
-  protected Object retrieveObjectForSampleConfig()
-  {
+  protected Object retrieveObjectForSampleConfig() {
     ServiceList serviceList = new ServiceList();
     serviceList.add(documentUploadService());
     serviceList.add(documentDownloadService());
@@ -282,8 +272,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
     return serviceList;
   }
 
-  private DocumentUploadService documentUploadService()
-  {
+  private DocumentUploadService documentUploadService() {
     DocumentUploadService service = new DocumentUploadService();
     service.setConnection(connection);
     service.setUsername(username);
@@ -291,8 +280,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
     return service;
   }
 
-  private DocumentDownloadService documentDownloadService()
-  {
+  private DocumentDownloadService documentDownloadService() {
     DocumentDownloadService service = new DocumentDownloadService();
     service.setConnection(connection);
     service.setUsername(username);
@@ -300,8 +288,7 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
     return service;
   }
 
-  private DocumentTransformService documentTransformService()
-  {
+  private DocumentTransformService documentTransformService() {
     DocumentTransformService service = new DocumentTransformService();
     service.setConnection(connection);
     service.setUsername(username);
@@ -309,4 +296,5 @@ public class DocumentUpDownServiceTest extends ExampleServiceCase
     service.setFormat(DocumentTransformService.Format.GLB);
     return service;
   }
+
 }

--- a/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumerTest.java
+++ b/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumerTest.java
@@ -1,32 +1,9 @@
 package com.adaptris.interlok.azure.onedrive;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.FixedIntervalPoller;
-import com.adaptris.core.MultiPayloadMessageFactory;
-import com.adaptris.core.Poller;
-import com.adaptris.core.QuartzCronPoller;
-import com.adaptris.core.StandaloneConsumer;
-import com.adaptris.core.stubs.MockMessageListener;
-import com.adaptris.core.util.LifecycleHelper;
-import com.adaptris.interlok.azure.AzureConnection;
-import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.adaptris.interlok.junit.scaffolding.ExampleConsumerCase;
-import com.adaptris.util.TimeInterval;
-import com.microsoft.graph.models.extensions.Drive;
-import com.microsoft.graph.models.extensions.DriveItem;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.requests.extensions.DriveRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionPage;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveItemContentStreamRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemContentStreamRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveItemRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveRequestBuilder;
-import com.microsoft.graph.requests.extensions.IUserRequestBuilder;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
@@ -38,13 +15,35 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
-public class OneDriveConsumerTest extends ExampleConsumerCase
-{
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.FixedIntervalPoller;
+import com.adaptris.core.MultiPayloadMessageFactory;
+import com.adaptris.core.Poller;
+import com.adaptris.core.QuartzCronPoller;
+import com.adaptris.core.StandaloneConsumer;
+import com.adaptris.core.stubs.MockMessageListener;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.azure.GraphAPIConnection;
+import com.adaptris.interlok.junit.scaffolding.ExampleConsumerCase;
+import com.adaptris.util.TimeInterval;
+import com.microsoft.graph.models.Drive;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.requests.DriveItemCollectionPage;
+import com.microsoft.graph.requests.DriveItemCollectionRequest;
+import com.microsoft.graph.requests.DriveItemCollectionRequestBuilder;
+import com.microsoft.graph.requests.DriveItemContentStreamRequest;
+import com.microsoft.graph.requests.DriveItemContentStreamRequestBuilder;
+import com.microsoft.graph.requests.DriveItemRequestBuilder;
+import com.microsoft.graph.requests.DriveRequest;
+import com.microsoft.graph.requests.DriveRequestBuilder;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.UserRequestBuilder;
+
+public class OneDriveConsumerTest extends ExampleConsumerCase {
   private static final String APPLICATION_ID = "47ea49b0-670a-47c1-9303-0b45ffb766ec";
   private static final String TENANT_ID = "cbf4a38d-3117-48cd-b54b-861480ee93cd";
   private static final String CLIENT_SECRET = "NGMyYjY0MTEtOTU0Ny00NTg0LWE3MzQtODg2ZDAzZGVmZmY1Cg==";
@@ -52,28 +51,21 @@ public class OneDriveConsumerTest extends ExampleConsumerCase
 
   private static final String CONTENT = "A bud light makes love to a Bacardi Silver about the Octoberfest. Now and then, the funny Amarillo Pale Ale seldom makes love to the steam engine of another girl scout. If the Pilsner beyond a burglar ale slurly satiates a shabby girl scout, then the change reads a magazine. A psychotic St. Pauli Girl dies, because the fat satellite brewery drunkenly finds lice on the financial Pilsner. When a Heineken near a Bridgeport ESB leaves, the air hocky table hesitates.";
 
-  private static final Poller[] POLLERS =
-  {
-    new FixedIntervalPoller(new TimeInterval(60L, TimeUnit.SECONDS)),
-    new QuartzCronPoller("0 */5 * * * ?"),
-  };
+  private static final Poller[] POLLERS = { new FixedIntervalPoller(new TimeInterval(60L, TimeUnit.SECONDS)),
+      new QuartzCronPoller("0 */5 * * * ?"), };
 
-  private AzureConnection connection;
+  private GraphAPIConnection connection;
   private OneDriveConsumer consumer;
 
   private boolean liveTests = false;
 
   @Before
-  public void setUp()
-  {
+  public void setUp() {
     Properties properties = new Properties();
-    try
-    {
+    try {
       properties.load(new FileInputStream(this.getClass().getResource("onedrive.properties").getFile()));
       liveTests = true;
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       // do nothing
     }
 
@@ -88,15 +80,13 @@ public class OneDriveConsumerTest extends ExampleConsumerCase
   }
 
   @Test
-  public void testLiveConsumer() throws Exception
-  {
+  public void testLiveConsumer() throws Exception {
     Assume.assumeTrue(liveTests);
 
     MockMessageListener mockMessageListener = new MockMessageListener(10);
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(connection, consumer);
     standaloneConsumer.registerAdaptrisMessageListener(mockMessageListener);
-    try
-    {
+    try {
       LifecycleHelper.init(standaloneConsumer);
       LifecycleHelper.prepare(standaloneConsumer);
       LifecycleHelper.start(standaloneConsumer);
@@ -107,20 +97,15 @@ public class OneDriveConsumerTest extends ExampleConsumerCase
 
       System.out.println("Found " + messages.size() + " files");
       Thread.sleep(5000); // sleep for 5 seconds, otherwise the Graph SDK complains we disconnected while waiting for a response
-    }
-    catch (InterruptedIOException | InterruptedException e)
-    {
+    } catch (InterruptedIOException | InterruptedException e) {
       // Ignore these as they're occasionally thrown by the Graph SDK when the connection is closed while it's still processing
-    }
-    finally
-    {
+    } finally {
       stop(standaloneConsumer);
     }
   }
 
   @Test
-  public void testMockConsumer() throws Exception
-  {
+  public void testMockConsumer() throws Exception {
     Assume.assumeFalse(liveTests);
 
     connection = mock(GraphAPIConnection.class);
@@ -129,15 +114,14 @@ public class OneDriveConsumerTest extends ExampleConsumerCase
     MockMessageListener mockMessageListener = new MockMessageListener(10);
     StandaloneConsumer standaloneConsumer = new StandaloneConsumer(connection, consumer);
     standaloneConsumer.registerAdaptrisMessageListener(mockMessageListener);
-    try
-    {
+    try {
       when(connection.retrieveConnection(any())).thenReturn(connection);
 
-      IGraphServiceClient client = mock(IGraphServiceClient.class);
+      GraphServiceClient client = mock(GraphServiceClient.class);
       when(connection.getClientConnection()).thenReturn(client);
-      IUserRequestBuilder userRequestBuilder = mock(IUserRequestBuilder.class);
+      UserRequestBuilder userRequestBuilder = mock(UserRequestBuilder.class);
       when(client.users(USERNAME)).thenReturn(userRequestBuilder);
-      IDriveRequestBuilder driveRequestBuilder = mock(IDriveRequestBuilder.class);
+      DriveRequestBuilder driveRequestBuilder = mock(DriveRequestBuilder.class);
       when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
       DriveRequest driveRequest = mock(DriveRequest.class);
       when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
@@ -145,23 +129,23 @@ public class OneDriveConsumerTest extends ExampleConsumerCase
       drive.id = "8e7a00f1daf1c2b7015459dd686856c2";
       when(driveRequest.get()).thenReturn(drive);
       when(userRequestBuilder.drives(drive.id)).thenReturn(driveRequestBuilder);
-      IDriveItemRequestBuilder driveItemRequestBuilder = mock(IDriveItemRequestBuilder.class);
+      DriveItemRequestBuilder driveItemRequestBuilder = mock(DriveItemRequestBuilder.class);
       when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
-      IDriveItemCollectionRequestBuilder childrenRequest = mock(IDriveItemCollectionRequestBuilder.class);
+      DriveItemCollectionRequestBuilder childrenRequest = mock(DriveItemCollectionRequestBuilder.class);
       when(driveItemRequestBuilder.children()).thenReturn(childrenRequest);
-      IDriveItemCollectionRequest children = mock(IDriveItemCollectionRequest.class);
+      DriveItemCollectionRequest children = mock(DriveItemCollectionRequest.class);
       when(childrenRequest.buildRequest()).thenReturn(children);
-      IDriveItemCollectionPage migraine = mock(IDriveItemCollectionPage.class);
+      DriveItemCollectionPage migraine = mock(DriveItemCollectionPage.class);
       when(children.get()).thenReturn(migraine);
       DriveItem fileReference = new DriveItem();
       fileReference.id = "73271d08680510a91aec95295ed03b90";
       fileReference.name = "beer";
-      fileReference.size = (long)CONTENT.length();
+      fileReference.size = (long) CONTENT.length();
       when(migraine.getCurrentPage()).thenReturn(Arrays.asList(fileReference));
       when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
-      IDriveItemContentStreamRequestBuilder streamRequestBuilder = mock(IDriveItemContentStreamRequestBuilder.class);
+      DriveItemContentStreamRequestBuilder streamRequestBuilder = mock(DriveItemContentStreamRequestBuilder.class);
       when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
-      IDriveItemContentStreamRequest streamRequest = mock(IDriveItemContentStreamRequest.class);
+      DriveItemContentStreamRequest streamRequest = mock(DriveItemContentStreamRequest.class);
       when(streamRequestBuilder.buildRequest()).thenReturn(streamRequest);
       when(streamRequest.get()).thenReturn(new ByteArrayInputStream(CONTENT.getBytes(Charset.defaultCharset())));
 
@@ -175,31 +159,24 @@ public class OneDriveConsumerTest extends ExampleConsumerCase
 
       assertEquals(1, messages.size());
       assertEquals(CONTENT, messages.get(0).getContent());
-    }
-    catch (InterruptedIOException | InterruptedException e)
-    {
+    } catch (InterruptedIOException | InterruptedException e) {
       // Ignore these as they're occasionally thrown by the Graph SDK when the connection is closed while it's still processing
-    }
-    finally
-    {
+    } finally {
       stop(standaloneConsumer);
     }
   }
 
   @Override
-  protected Object retrieveObjectForSampleConfig()
-  {
+  protected Object retrieveObjectForSampleConfig() {
     return new StandaloneConsumer(connection, consumer);
   }
 
   @Override
-  protected List<StandaloneConsumer> retrieveObjectsForSampleConfig()
-  {
-    List<StandaloneConsumer> result = new ArrayList();
-    for (Poller poller : POLLERS)
-    {
-      StandaloneConsumer standaloneConsumer = (StandaloneConsumer)retrieveObjectForSampleConfig();
-      ((OneDriveConsumer)standaloneConsumer.getConsumer()).setPoller(poller);
+  protected List<StandaloneConsumer> retrieveObjectsForSampleConfig() {
+    List<StandaloneConsumer> result = new ArrayList<>();
+    for (Poller poller : POLLERS) {
+      StandaloneConsumer standaloneConsumer = (StandaloneConsumer) retrieveObjectForSampleConfig();
+      ((OneDriveConsumer) standaloneConsumer.getConsumer()).setPoller(poller);
       result.add(standaloneConsumer);
     }
     return result;

--- a/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumerTest.java
+++ b/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumerTest.java
@@ -181,4 +181,5 @@ public class OneDriveConsumerTest extends ExampleConsumerCase {
     }
     return result;
   }
+
 }

--- a/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveProducerTest.java
+++ b/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveProducerTest.java
@@ -1,27 +1,10 @@
 package com.adaptris.interlok.azure.onedrive;
 
-import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.StandaloneProducer;
-import com.adaptris.interlok.azure.AzureConnection;
-import com.adaptris.interlok.azure.GraphAPIConnection;
-import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
-import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
-import com.microsoft.graph.models.extensions.DriveItem;
-import com.microsoft.graph.models.extensions.IGraphServiceClient;
-import com.microsoft.graph.requests.extensions.DriveRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionPage;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemCollectionRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveItemContentStreamRequest;
-import com.microsoft.graph.requests.extensions.IDriveItemContentStreamRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveItemRequestBuilder;
-import com.microsoft.graph.requests.extensions.IDriveRequestBuilder;
-import com.microsoft.graph.requests.extensions.IUserRequestBuilder;
-import org.apache.commons.io.FileUtils;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.FileInputStream;
 import java.nio.charset.Charset;
@@ -30,14 +13,30 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
 
-public class OneDriveProducerTest extends ExampleProducerCase
-{
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.StandaloneProducer;
+import com.adaptris.interlok.azure.GraphAPIConnection;
+import com.adaptris.interlok.junit.scaffolding.ExampleProducerCase;
+import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.requests.DriveItemCollectionPage;
+import com.microsoft.graph.requests.DriveItemCollectionRequest;
+import com.microsoft.graph.requests.DriveItemCollectionRequestBuilder;
+import com.microsoft.graph.requests.DriveItemContentStreamRequest;
+import com.microsoft.graph.requests.DriveItemContentStreamRequestBuilder;
+import com.microsoft.graph.requests.DriveItemRequestBuilder;
+import com.microsoft.graph.requests.DriveRequest;
+import com.microsoft.graph.requests.DriveRequestBuilder;
+import com.microsoft.graph.requests.GraphServiceClient;
+import com.microsoft.graph.requests.UserRequestBuilder;
+
+public class OneDriveProducerTest extends ExampleProducerCase {
   private static final String APPLICATION_ID = "47ea49b0-670a-47c1-9303-0b45ffb766ec";
   private static final String TENANT_ID = "cbf4a38d-3117-48cd-b54b-861480ee93cd";
   private static final String CLIENT_SECRET = "NGMyYjY0MTEtOTU0Ny00NTg0LWE3MzQtODg2ZDAzZGVmZmY1Cg==";
@@ -46,22 +45,18 @@ public class OneDriveProducerTest extends ExampleProducerCase
   private static final String FILENAME = "cupcake.txt";
   private static final String MESSAGE = "Cupcake ipsum dolor sit amet sesame snaps. Caramels carrot cake cookie sesame snaps muffin gummi bears sweet. Carrot cake macaroon jelly ice cream muffin pastry. Jelly bonbon icing toffee macaroon topping liquorice ice cream chocolate. Powder dragée wafer sugar plum chupa chups cheesecake. Cheesecake tiramisu ice cream marshmallow gingerbread sesame snaps. Lemon drops chocolate wafer cake toffee bonbon toffee soufflé danish. Muffin caramels tootsie roll dragée candy canes danish apple pie fruitcake. Caramels chocolate bar cotton candy. Candy canes halvah cotton candy. Fruitcake jelly candy canes bear claw croissant jelly-o cookie. Pie dragée apple pie toffee dragée topping tiramisu jujubes. Cookie oat cake jujubes chocolate cake.";
 
-  private AzureConnection connection;
+  private GraphAPIConnection connection;
   private OneDriveProducer producer;
 
   private boolean liveTests = false;
 
   @Before
-  public void setUp()
-  {
+  public void setUp() {
     Properties properties = new Properties();
-    try
-    {
+    try {
       properties.load(new FileInputStream(this.getClass().getResource("onedrive.properties").getFile()));
       liveTests = true;
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       // do nothing
     }
 
@@ -77,8 +72,7 @@ public class OneDriveProducerTest extends ExampleProducerCase
   }
 
   @Test
-  public void testLiveProducer() throws Exception
-  {
+  public void testLiveProducer() throws Exception {
     Assume.assumeTrue(liveTests);
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
@@ -87,18 +81,15 @@ public class OneDriveProducerTest extends ExampleProducerCase
   }
 
   @Test
-  public void testLiveProducerLarge() throws Exception
-  {
+  public void testLiveProducerLarge() throws Exception {
     Assume.assumeTrue(liveTests);
 
     producer.setFilename("big-data.txt");
 
     StringBuilder bigData = new StringBuilder();
-    do
-    {
+    do {
       bigData.append(MESSAGE).append("\n");
-    }
-    while (bigData.length() < 4 * FileUtils.ONE_MB);
+    } while (bigData.length() < 4 * FileUtils.ONE_MB);
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(bigData.toString());
     StandaloneProducer standaloneProducer = new StandaloneProducer(connection, producer);
@@ -106,43 +97,42 @@ public class OneDriveProducerTest extends ExampleProducerCase
   }
 
   @Test
-  public void testMockProducerOverwrite() throws Exception
-  {
+  public void testMockProducerOverwrite() throws Exception {
     Assume.assumeFalse(liveTests);
 
     connection = mock(GraphAPIConnection.class);
     producer.registerConnection(connection);
 
     when(connection.retrieveConnection(any())).thenReturn(connection);
-    IGraphServiceClient client = mock(IGraphServiceClient.class);
+    GraphServiceClient client = mock(GraphServiceClient.class);
     when(connection.getClientConnection()).thenReturn(client);
 
-    IUserRequestBuilder userRequestBuilder = mock(IUserRequestBuilder.class);
+    UserRequestBuilder userRequestBuilder = mock(UserRequestBuilder.class);
     when(client.users(USERNAME)).thenReturn(userRequestBuilder);
-    IDriveRequestBuilder driveRequestBuilder = mock(IDriveRequestBuilder.class);
+    DriveRequestBuilder driveRequestBuilder = mock(DriveRequestBuilder.class);
     when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
     DriveRequest driveRequest = mock(DriveRequest.class);
     when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
 
-    IDriveItemRequestBuilder driveItemRequestBuilder = mock(IDriveItemRequestBuilder.class);
+    DriveItemRequestBuilder driveItemRequestBuilder = mock(DriveItemRequestBuilder.class);
     when(driveRequestBuilder.root()).thenReturn(driveItemRequestBuilder);
-    IDriveItemCollectionRequestBuilder childrenRequest = mock(IDriveItemCollectionRequestBuilder.class);
+    DriveItemCollectionRequestBuilder childrenRequest = mock(DriveItemCollectionRequestBuilder.class);
     when(driveItemRequestBuilder.children()).thenReturn(childrenRequest);
-    IDriveItemCollectionRequest children = mock(IDriveItemCollectionRequest.class);
+    DriveItemCollectionRequest children = mock(DriveItemCollectionRequest.class);
     when(childrenRequest.buildRequest()).thenReturn(children);
-    IDriveItemCollectionPage migraine = mock(IDriveItemCollectionPage.class);
+    DriveItemCollectionPage migraine = mock(DriveItemCollectionPage.class);
     when(children.get()).thenReturn(migraine);
 
     DriveItem fileReference = new DriveItem();
     fileReference.id = "73271d08680510a91aec95295ed03b90";
     fileReference.name = FILENAME;
-    fileReference.size = (long)MESSAGE.length();
+    fileReference.size = (long) MESSAGE.length();
     when(migraine.getCurrentPage()).thenReturn(Arrays.asList(fileReference));
 
     when(driveRequestBuilder.items(fileReference.id)).thenReturn(driveItemRequestBuilder);
-    IDriveItemContentStreamRequestBuilder streamRequestBuilder = mock(IDriveItemContentStreamRequestBuilder.class);
+    DriveItemContentStreamRequestBuilder streamRequestBuilder = mock(DriveItemContentStreamRequestBuilder.class);
     when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
-    IDriveItemContentStreamRequest streamRequest = mock(IDriveItemContentStreamRequest.class);
+    DriveItemContentStreamRequest streamRequest = mock(DriveItemContentStreamRequest.class);
     when(streamRequestBuilder.buildRequest()).thenReturn(streamRequest);
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
@@ -153,8 +143,7 @@ public class OneDriveProducerTest extends ExampleProducerCase
   }
 
   @Test
-  public void testMockProducerNoOverwrite() throws Exception
-  {
+  public void testMockProducerNoOverwrite() throws Exception {
     Assume.assumeFalse(liveTests);
 
     connection = mock(GraphAPIConnection.class);
@@ -162,30 +151,30 @@ public class OneDriveProducerTest extends ExampleProducerCase
     producer.setOverwrite(false);
 
     when(connection.retrieveConnection(any())).thenReturn(connection);
-    IGraphServiceClient client = mock(IGraphServiceClient.class);
+    GraphServiceClient client = mock(GraphServiceClient.class);
     when(connection.getClientConnection()).thenReturn(client);
 
-    IUserRequestBuilder userRequestBuilder = mock(IUserRequestBuilder.class);
+    UserRequestBuilder userRequestBuilder = mock(UserRequestBuilder.class);
     when(client.users(USERNAME)).thenReturn(userRequestBuilder);
-    IDriveRequestBuilder driveRequestBuilder = mock(IDriveRequestBuilder.class);
+    DriveRequestBuilder driveRequestBuilder = mock(DriveRequestBuilder.class);
     when(userRequestBuilder.drive()).thenReturn(driveRequestBuilder);
     DriveRequest driveRequest = mock(DriveRequest.class);
     when(driveRequestBuilder.buildRequest()).thenReturn(driveRequest);
 
-    IDriveItemCollectionRequestBuilder driveItemsRequestBuilder = mock(IDriveItemCollectionRequestBuilder.class);
+    DriveItemCollectionRequestBuilder driveItemsRequestBuilder = mock(DriveItemCollectionRequestBuilder.class);
     when(driveRequestBuilder.items()).thenReturn(driveItemsRequestBuilder);
-    IDriveItemCollectionRequest driveItemRequest = mock(IDriveItemCollectionRequest.class);
+    DriveItemCollectionRequest driveItemRequest = mock(DriveItemCollectionRequest.class);
     when(driveItemsRequestBuilder.buildRequest()).thenReturn(driveItemRequest);
 
     DriveItem newItem = new DriveItem();
     newItem.id = "";
     when(driveItemRequest.post(any(DriveItem.class))).thenReturn(newItem);
 
-    IDriveItemRequestBuilder driveItemRequestBuilder = mock(IDriveItemRequestBuilder.class);
+    DriveItemRequestBuilder driveItemRequestBuilder = mock(DriveItemRequestBuilder.class);
     when(driveRequestBuilder.items(newItem.id)).thenReturn(driveItemRequestBuilder);
-    IDriveItemContentStreamRequestBuilder streamRequestBuilder = mock(IDriveItemContentStreamRequestBuilder.class);
+    DriveItemContentStreamRequestBuilder streamRequestBuilder = mock(DriveItemContentStreamRequestBuilder.class);
     when(driveItemRequestBuilder.content()).thenReturn(streamRequestBuilder);
-    IDriveItemContentStreamRequest streamRequest = mock(IDriveItemContentStreamRequest.class);
+    DriveItemContentStreamRequest streamRequest = mock(DriveItemContentStreamRequest.class);
     when(streamRequestBuilder.buildRequest()).thenReturn(streamRequest);
 
     AdaptrisMessage message = AdaptrisMessageFactory.getDefaultInstance().newMessage(MESSAGE);
@@ -196,14 +185,12 @@ public class OneDriveProducerTest extends ExampleProducerCase
   }
 
   @Override
-  protected Object retrieveObjectForSampleConfig()
-  {
+  protected Object retrieveObjectForSampleConfig() {
     return new StandaloneProducer(connection, producer);
   }
 
   @Override
-  protected List<StandaloneProducer> retrieveObjectsForSampleConfig()
-  {
-    return Collections.singletonList((StandaloneProducer)retrieveObjectForSampleConfig());
+  protected List<StandaloneProducer> retrieveObjectsForSampleConfig() {
+    return Collections.singletonList((StandaloneProducer) retrieveObjectForSampleConfig());
   }
 }

--- a/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveProducerTest.java
+++ b/interlok-azure-onedrive/src/test/java/com/adaptris/interlok/azure/onedrive/OneDriveProducerTest.java
@@ -193,4 +193,5 @@ public class OneDriveProducerTest extends ExampleProducerCase {
   protected List<StandaloneProducer> retrieveObjectsForSampleConfig() {
     return Collections.singletonList((StandaloneProducer) retrieveObjectForSampleConfig());
   }
+
 }


### PR DESCRIPTION
## Motivation

At the moment the mail consumer in azure mail works but the problem is that the oauth toke used expired after 1h (default azure setting) and there is no way to refresh it.

## Modification

- Update to the latest microsoft graph lib 5.x.x which has a lot of new components and some that handle token and refresh token.
- Refactoring
- Code formatting

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

The mail consumer keep working even after the token has expired as it has been refreshed

## Testing

Tested by CW on 3.12
