### PR TITLE
INTERLOK-3921 Support the search param in the O365MailConsumer.

### DIFF
--- a/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailConsumerTest.java
+++ b/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailConsumerTest.java
@@ -2,6 +2,7 @@ package com.adaptris.interlok.azure.mail;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -153,7 +154,7 @@ public class O365MailConsumerTest extends ExampleConsumerCase {
       MessageCollectionRequestBuilder messageCollectionRequestBuilder = mock(MessageCollectionRequestBuilder.class);
       when(mailRequestBuilder.messages()).thenReturn(messageCollectionRequestBuilder);
       MessageCollectionRequest messageCollectionRequest = mock(MessageCollectionRequest.class);
-      when(messageCollectionRequestBuilder.buildRequest()).thenReturn(messageCollectionRequest);
+      when(messageCollectionRequestBuilder.buildRequest(anyList())).thenReturn(messageCollectionRequest);
       when(messageCollectionRequest.filter(O365MailConsumer.DEFAULT_FILTER)).thenReturn(messageCollectionRequest);
       MessageCollectionPage messageResponse = mock(MessageCollectionPage.class);
       when(messageCollectionRequest.get()).thenReturn(messageResponse);

--- a/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailConsumerTest.java
+++ b/interlok-azure-mail/src/test/java/com/adaptris/interlok/azure/mail/O365MailConsumerTest.java
@@ -106,6 +106,32 @@ public class O365MailConsumerTest extends ExampleConsumerCase {
   }
 
   @Test
+  public void testLiveConsumerWithSearch() throws Exception {
+    Assume.assumeTrue(liveTests);
+
+    MockMessageListener mockMessageListener = new MockMessageListener(10);
+    consumer.setSearch("subject:A subject");
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(connection, consumer);
+    standaloneConsumer.registerAdaptrisMessageListener(mockMessageListener);
+    try {
+      LifecycleHelper.init(standaloneConsumer);
+      LifecycleHelper.prepare(standaloneConsumer);
+      LifecycleHelper.start(standaloneConsumer);
+
+      waitForMessages(mockMessageListener, 5, 10000); // Wait until we get five new emails or for 10 seconds
+
+      List<AdaptrisMessage> messages = mockMessageListener.getMessages();
+
+      System.out.println("Found " + messages.size() + " emails");
+      Thread.sleep(5000); // Sleep for 5 seconds, otherwise the Graph SDK complains we disconnected while waiting for a response
+    } catch (InterruptedIOException | InterruptedException e) {
+      // Ignore these as they're occasionally thrown by the Graph SDK when the connection is closed while it's still processing
+    } finally {
+      stop(standaloneConsumer);
+    }
+  }
+
+  @Test
   public void testMockConsumer() throws Exception {
     Assume.assumeFalse(liveTests);
 
@@ -171,6 +197,27 @@ public class O365MailConsumerTest extends ExampleConsumerCase {
     } finally {
       stop(standaloneConsumer);
     }
+  }
+
+  @Test
+  public void testQueryOptionWithSearch() throws Exception {
+    O365MailConsumer consumer = new O365MailConsumer();
+    consumer.setSearch("subject:\"subject\"");
+
+    assertEquals(2, consumer.queryOptions().size());
+    assertEquals(O365MailConsumer.CONSISTENCY_LEVEL_OPTION, consumer.queryOptions().get(0).getName());
+    assertEquals("eventual", consumer.queryOptions().get(0).getValue());
+    assertEquals(O365MailConsumer.SEARCH_OPTION, consumer.queryOptions().get(1).getName());
+    assertEquals("\"subject:\"subject\"\"", consumer.queryOptions().get(1).getValue());
+  }
+
+  @Test
+  public void testQueryOptionNoSearch() throws Exception {
+    O365MailConsumer consumer = new O365MailConsumer();
+
+    assertEquals(1, consumer.queryOptions().size());
+    assertEquals(O365MailConsumer.FILTER_OPTION, consumer.queryOptions().get(0).getName());
+    assertEquals(O365MailConsumer.DEFAULT_FILTER, consumer.queryOptions().get(0).getValue());
   }
 
   @Override


### PR DESCRIPTION
## Motivation

The filter option in the mail consumer is limited, for instance to and subject are not supported.

## Modification

- Support the search option as well as the filter option so uses can chose which one is better suited for their use case.
- Search and filter cannot be used at the same time so if search is is used filter is ignored.
- Update javadocs.
- Add some test.
- Refactoring.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

The user can either use the filter or the search to retrieve a limited amount of emails.

## Testing

It has already been tested by CW.
