### PR TITLE
Feature/interlok 4477

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.0-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '5.0-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.1-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '5.1-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/AzureConnection.java
@@ -1,6 +1,6 @@
 package com.adaptris.interlok.azure;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
+++ b/interlok-azure-core/src/main/java/com/adaptris/interlok/azure/DataLakeConnection.java
@@ -1,6 +1,6 @@
 package com.adaptris.interlok.azure;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeader.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeader.java
@@ -20,7 +20,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderFromUrl.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderFromUrl.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import java.net.URL;
 
 /**

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderImpl.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationHeaderImpl.java
@@ -12,7 +12,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * Abstract base class for generating Authorization headers.

--- a/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
+++ b/interlok-azure-cosmosdb/src/main/java/com/adaptris/interlok/azure/cosmosdb/CosmosAuthorizationInterceptor.java
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;

--- a/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeConsumer.java
+++ b/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeConsumer.java
@@ -18,7 +18,7 @@ package com.adaptris.interlok.azure.datalake;
 
 import java.io.OutputStream;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import org.apache.commons.io.FilenameUtils;
 

--- a/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeProducer.java
+++ b/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeProducer.java
@@ -2,7 +2,7 @@ package com.adaptris.interlok.azure.datalake;
 
 import java.io.InputStream;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import org.apache.commons.lang3.BooleanUtils;
 

--- a/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeUploadService.java
+++ b/interlok-azure-datalake/src/main/java/com/adaptris/interlok/azure/datalake/DataLakeUploadService.java
@@ -19,8 +19,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 /**
  * Upload files to Microsoft Data Lake.

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumer.java
@@ -25,10 +25,10 @@ import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.mail.BodyPart;
-import javax.mail.MessagingException;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
+import jakarta.mail.BodyPart;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumerImpl.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailConsumerImpl.java
@@ -19,7 +19,7 @@ package com.adaptris.interlok.azure.mail;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailProducer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365MailProducer.java
@@ -4,7 +4,7 @@ import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;

--- a/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365RawMailConsumer.java
+++ b/interlok-azure-mail/src/main/java/com/adaptris/interlok/azure/mail/O365RawMailConsumer.java
@@ -22,9 +22,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;
 
-import javax.mail.Session;
-import javax.mail.internet.MimeMessage;
-import javax.validation.Valid;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.validation.Valid;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentDownloadService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentDownloadService.java
@@ -4,8 +4,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import org.apache.commons.io.IOUtils;
 

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentTransformService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentTransformService.java
@@ -2,7 +2,7 @@ package com.adaptris.interlok.azure.onedrive;
 
 import java.util.LinkedList;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentUploadService.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/DocumentUploadService.java
@@ -1,7 +1,7 @@
 package com.adaptris.interlok.azure.onedrive;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumer.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveConsumer.java
@@ -19,7 +19,7 @@ package com.adaptris.interlok.azure.onedrive;
 import java.io.InputStream;
 import java.util.List;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;

--- a/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveProducer.java
+++ b/interlok-azure-onedrive/src/main/java/com/adaptris/interlok/azure/onedrive/OneDriveProducer.java
@@ -2,7 +2,7 @@ package com.adaptris.interlok.azure.onedrive;
 
 import java.util.Optional;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.BooleanUtils;


### PR DESCRIPTION
## Motivation

INTERLOK-4477: Upgrade jakarta and jetty, make release version 5.1-SNAPSHOT

## Modification
Updated necessary dependencies and imports to use jakarta instead of javax


## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Compatibility with future versions of jakarta/jetty

## Testing


